### PR TITLE
Delete default copy constructor

### DIFF
--- a/include/resource_retriever/retriever.h
+++ b/include/resource_retriever/retriever.h
@@ -79,6 +79,8 @@ public:
 
 private:
   CURL* curl_handle_;
+
+  Retriever(const Retriever & ret) = delete;
 };
 
 } // namespace resource_retriever

--- a/include/resource_retriever/retriever.h
+++ b/include/resource_retriever/retriever.h
@@ -78,9 +78,9 @@ public:
   MemoryResource get(const std::string& url);
 
 private:
-  CURL* curl_handle_;
-
   Retriever(const Retriever & ret) = delete;
+
+  CURL* curl_handle_;
 };
 
 } // namespace resource_retriever


### PR DESCRIPTION
Potential fix #1. Breaks ABI so I am making a kinetic-devel branch for this change.
