### PR TITLE
Gracefully degrade to private undefined copy constructor for C++03.

### DIFF
--- a/include/resource_retriever/retriever.h
+++ b/include/resource_retriever/retriever.h
@@ -78,7 +78,11 @@ public:
   MemoryResource get(const std::string& url);
 
 private:
+#if __cplusplus >= 201103L
   Retriever(const Retriever & ret) = delete;
+#else
+  Retriever(const Retriever &);
+#endif
 
   CURL* curl_handle_;
 };


### PR DESCRIPTION
This PR degrades to using a private declared-but-not-defined copy constructor for compilers pre-C++11. I'm not necessarily of the opinion this should be merged, but it is worth consideration.

`rviz` for example is compiling with a warning because it is not enabling C++11 support while it is including `retriever.h`. The fact that this is a warning and not an error is actually a bit surprising to me, but basically `resource_retriever` has two choices: either require everything depending on it to compile with C++11 support (or later), or be pragmatic and avoid C++11 features in the public header.

Another question is: if `resource_retriever` requires C++11 support to use, should this be communicated somehow? Forcing compiler flags using catkin/cmake seems like a bad idea. The warning currently generated by gcc might already be sufficient I suppose, in which case no action is required at all and this can be closed :)
