### PR TITLE
Python3 compatibility

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,6 @@
   <run_depend>curl</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>roslib</run_depend>
-  <run_depend>rospkg</run_depend>
+  <run_depend>python-rospkg</run_depend>
 
 </package>

--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,5 @@
   <run_depend>curl</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>roslib</run_depend>
-  <run_depend>python-urlgrabber</run_depend>
 
 </package>

--- a/package.xml
+++ b/package.xml
@@ -28,5 +28,6 @@
   <run_depend>curl</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>roslib</run_depend>
+  <run_depend>rospkg</run_depend>
 
 </package>

--- a/src/resource_retriever/__init__.py
+++ b/src/resource_retriever/__init__.py
@@ -33,6 +33,7 @@
 
 import roslib; roslib.load_manifest('resource_retriever')
 import subprocess
+import rospkg
 try:
     from urllib.request import urlopen
     from urllib.error import URLError
@@ -41,14 +42,7 @@ except ImportError:
     from urllib2 import URLError
 
 PACKAGE_PREFIX = 'package://'
-
-def rospack_find(package):
-    process = subprocess.Popen(['rospack', 'find', package], shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    (stdout, stderr) = process.communicate()
-    if len(stderr) > 0:
-        raise Exception(stderr)
-    else:
-        return string.strip(stdout)
+r = rospkg.RosPack()
 
 def get_filename(url, use_protocol=True ):
     mod_url = url
@@ -60,7 +54,7 @@ def get_filename(url, use_protocol=True ):
 
         package = mod_url[0:pos]
         mod_url = mod_url[pos:]
-        package_path = rospack_find(package)
+        package_path = r.get_path(package)
 
         if use_protocol:
             protocol = "file://"

--- a/src/resource_retriever/__init__.py
+++ b/src/resource_retriever/__init__.py
@@ -33,7 +33,12 @@
 
 import roslib; roslib.load_manifest('resource_retriever')
 import subprocess
-import urlgrabber, string
+try:
+    from urllib.request import urlopen
+    from urllib.error import URLError
+except ImportError:
+    from urllib2 import urlopen
+    from urllib2 import URLError
 
 PACKAGE_PREFIX = 'package://'
 
@@ -65,5 +70,8 @@ def get_filename(url, use_protocol=True ):
     return mod_url
 
 def get(url):
-    return urlgrabber.urlopen(get_filename(url))
-
+    filename = get_filename(url)
+    try:
+        return urlopen(filename).read()
+    except URLError:
+        raise Exception("Invalid URL: {}".format(filename))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,3 +2,5 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 
 catkin_add_gtest(${PROJECT_NAME}_utest test.cpp)
 target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME})
+
+catkin_add_nosetests(test.py)

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,36 @@
+import resource_retriever as r
+
+import os
+import rospkg
+from nose.tools import raises
+
+rospack = rospkg.RosPack()
+
+def test_get_by_package():
+    res = r.get("package://resource_retriever/test/test.txt")
+    assert len(res) == 1
+    assert res == 'A'.encode()
+
+def test_get_large_file():
+    res_path = os.path.join(rospack.get_path("resource_retriever"), "test/large_file.dat")
+    with open(res_path, 'w') as f:
+        for _ in range(1024*1024*50):
+            f.write('A')
+    res = r.get("package://resource_retriever/test/large_file.dat")
+    assert len(res) == 1024*1024*50
+
+def test_http():
+    res = r.get("http://packages.ros.org/ros.key")
+    assert len(res) > 0
+
+@raises(Exception)
+def test_invalid_file():
+    r.get("file://fail")
+
+@raises(Exception)
+def test_no_file():
+    r.get("package://roscpp")
+
+@raises(rospkg.common.ResourceNotFound)
+def test_invalid_package():
+    r.get("package://invalid_package_blah/test.xml")


### PR DESCRIPTION
urlgrabber is not available for python3 (at least not on OSX) so I replaced the urlgrabber usage in the python version of resource_retriever with the python built in urllib/urllib2.
In addition I replaced the home baked rospack_find by rospkg and added unit tests for the python api.