### PR TITLE
add missing dependency on pkg-config

### DIFF
--- a/libcurl_vendor/package.xml
+++ b/libcurl_vendor/package.xml
@@ -17,6 +17,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <buildtool_export_depend>pkg-config</buildtool_export_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
After being merged this patch needs to be cherry-picked into the `ardent` branch and a new patch release has to be made.