### PR TITLE
Make sure to export the include directory for resource_retriever.

### DIFF
--- a/resource_retriever/CMakeLists.txt
+++ b/resource_retriever/CMakeLists.txt
@@ -33,8 +33,8 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "RESOURCE_RETRIEVER_BUILDING_
 
 # specific order: dependents before dependencies
 ament_export_include_directories(include)
-
 ament_export_interfaces(${PROJECT_NAME})
+
 ament_export_dependencies(ament_index_cpp)
 ament_export_dependencies(libcurl_vendor)
 

--- a/resource_retriever/CMakeLists.txt
+++ b/resource_retriever/CMakeLists.txt
@@ -31,10 +31,12 @@ ament_target_dependencies(${PROJECT_NAME}
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RESOURCE_RETRIEVER_BUILDING_LIBRARY")
 
+# specific order: dependents before dependencies
+ament_export_include_directories(include)
+
 ament_export_interfaces(${PROJECT_NAME})
 ament_export_dependencies(ament_index_cpp)
 ament_export_dependencies(libcurl_vendor)
-ament_export_include_directories(include)
 
 if(BUILD_TESTING)
   # TODO(wjwwood): add ament linters

--- a/resource_retriever/CMakeLists.txt
+++ b/resource_retriever/CMakeLists.txt
@@ -34,6 +34,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "RESOURCE_RETRIEVER_BUILDING_
 ament_export_interfaces(${PROJECT_NAME})
 ament_export_dependencies(ament_index_cpp)
 ament_export_dependencies(libcurl_vendor)
+ament_export_include_directories(include)
 
 if(BUILD_TESTING)
   # TODO(wjwwood): add ament linters


### PR DESCRIPTION
Otherwise, it can't properly be used as a library.

fixes #21 

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>