### PR TITLE
depend on curl (libcurl-dev, curl) for packaging

### DIFF
--- a/libcurl_vendor/package.xml
+++ b/libcurl_vendor/package.xml
@@ -19,6 +19,8 @@
 
   <buildtool_export_depend>pkg-config</buildtool_export_depend>
 
+  <depend>curl</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
Defining the dependency on `curl` allows us to not build it from source but just depend on the upstream version.
Copied from: https://github.com/ros2-gbp/resource_retriever-release/tree/5597bf018cfe1bcf3e323c50801bb89c946e9061/ubuntu/libcurl_vendor

The key resolves to `libcurl-dev` and `curl`: 
https://github.com/ros/rosdistro/blob/f236f31615f7eb1667e94cba66f212ddcb80829b/rosdep/base.yaml#L524

@nuclearsandwich @wjwwood @clalancette FYI