### PR TITLE
Export resource retriever to enable hooks.

### DIFF
--- a/resource_retriever/CMakeLists.txt
+++ b/resource_retriever/CMakeLists.txt
@@ -34,6 +34,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "RESOURCE_RETRIEVER_BUILDING_
 # specific order: dependents before dependencies
 ament_export_include_directories(include)
 ament_export_interfaces(${PROJECT_NAME})
+ament_export_libraries(${PROJECT_NAME})
 
 ament_export_dependencies(ament_index_cpp)
 ament_export_dependencies(libcurl_vendor)

--- a/resource_retriever/CMakeLists.txt
+++ b/resource_retriever/CMakeLists.txt
@@ -33,8 +33,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "RESOURCE_RETRIEVER_BUILDING_
 
 # specific order: dependents before dependencies
 ament_export_include_directories(include)
-ament_export_interfaces(${PROJECT_NAME})
-ament_export_libraries(${PROJECT_NAME})
+ament_export_interfaces(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 ament_export_dependencies(ament_index_cpp)
 ament_export_dependencies(libcurl_vendor)


### PR DESCRIPTION
Add `ament_export_libraries` call to export the library and set necessary environment hooks. This package is one of a handful which installs libraries without setting an environment hook to add them to the platform library path.

Connects to ros2/ros_workspace#10