### PR TITLE
point to the ros/resource_retriever repository

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,8 +18,8 @@
   <license>BSD</license>
 
   <url type="website">http://ros.org/wiki/resource_retriever</url>
-  <url type="repository">https://github.com/ros/robot_model</url>
-  <url type="bugtracker">https://github.com/ros/robot_model/issues</url>
+  <url type="repository">https://github.com/ros/resource_retriever</url>
+  <url type="bugtracker">https://github.com/ros/resource_retriever/issues</url>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 


### PR DESCRIPTION
Currently the [ROS wiki page](http://wiki.ros.org/resource_retriever) points to https://github.com/ros/robot_model

Maybe worth also mentioning on the [robot_model's README](https://github.com/ros/robot_model/blob/kinetic-devel/README.md)