### PR TITLE
Catch ament_index_cpp::PackageNotFoundError

### DIFF
--- a/resource_retriever/src/retriever.cpp
+++ b/resource_retriever/src/retriever.cpp
@@ -34,6 +34,7 @@
 
 #include <curl/curl.h>
 
+#include "ament_index_cpp/get_package_prefix.hpp"
 #include "ament_index_cpp/get_package_share_directory.hpp"
 
 namespace resource_retriever
@@ -111,10 +112,10 @@ MemoryResource Retriever::get(const std::string& url)
 
     std::string package = mod_url.substr(0, pos);
     mod_url.erase(0, pos);
-    std::string package_path = ament_index_cpp::get_package_share_directory(package);
-
-    if (package_path.empty())
-    {
+    std::string package_path;
+    try {
+      package_path = ament_index_cpp::get_package_share_directory(package);
+    } catch (const ament_index_cpp::PackageNotFoundError &) {
       throw Exception(url, "Package [" + package + "] does not exist");
     }
 


### PR DESCRIPTION
This fixes a crash in rviz2. It should probably be backported to dashing and eloquent, though I've only tested on the latest ROS 2 sources.

To reproduce:

Save the following as `pkg_dne.urdf`

```xml
<?xml version="1.0" ?>
<robot name="does_not_exist">
  <link name="base_link">
    <visual>
      <geometry>
        <mesh filename="package://package_does_not_exist/meshes/base.stl"/>
      </geometry>
    </visual>
  </link>
</robot>
```
 
Publish it using `robot_state_publisher`

```console
ros2 run robot_state_publisher robot_state_publisher pkg_dne.urdf
```

Launch rviz2 and add a `RobotModel` display. Tell the display to use the description topic `/robot_description`. RViz will immediately crash.

```
Parsing robot urdf xml string.
terminate called after throwing an instance of 'ament_index_cpp::PackageNotFoundError'
  what():  package 'package_does_not_exist' not found, searching: [...
```

With this PR, RViz will log errors but continue to run
```
Parsing robot urdf xml string.
[ERROR] [rviz2]: Error retrieving file [package://package_does_not_exist/meshes/base.stl]: Package [package_does_not_exist] does not exist
[ERROR] [rviz2]: FileNotFoundException: Cannot locate resource package://package_does_not_exist/meshes/base.stl in resource group OgreAutodetect. in ResourceGroupManager::openResource at /home/sloretz/ws/ros2/build/rviz_ogre_vendor/ogre-v1.12.1-prefix/src/ogre-v1.12.1/OgreMain/src/OgreResourceGroupManager.cpp (line 705)
[ERROR] [rviz2]: could not load model 'package://package_does_not_exist/meshes/base.stl' for link 'base_link': FileNotFoundException: Cannot locate resource package://package_does_not_exist/meshes/base.stl in resource group OgreAutodetect. in ResourceGroupManager::openResource at /home/sloretz/ws/ros2/build/rviz_ogre_vendor/ogre-v1.12.1-prefix/src/ogre-v1.12.1/OgreMain/src/OgreResourceGroupManager.cpp (line 705)
[ERROR] [rviz2]: Error retrieving file [package://package_does_not_exist/meshes/base.stl]: Package [package_does_not_exist] does not exist
[ERROR] [rviz2]: FileNotFoundException: Cannot locate resource package://package_does_not_exist/meshes/base.stl in resource group OgreAutodetect. in ResourceGroupManager::openResource at /home/sloretz/ws/ros2/build/rviz_ogre_vendor/ogre-v1.12.1-prefix/src/ogre-v1.12.1/OgreMain/src/OgreResourceGroupManager.cpp (line 705)
[ERROR] [rviz2]: could not load model 'package://package_does_not_exist/meshes/base.stl' for link 'base_link': FileNotFoundException: Cannot locate resource package://package_does_not_exist/meshes/base.stl in resource group OgreAutodetect. in ResourceGroupManager::openResource at /home/sloretz/ws/ros2/build/rviz_ogre_vendor/ogre-v1.12.1-prefix/src/ogre-v1.12.1/OgreMain/src/OgreResourceGroupManager.cpp (line 705)
```


Side note, RViz only crashes if the mesh type is `stl`. If I change it to `dae` then RViz does not crash, even without this PR. I don't know the reason for the difference. @wjwwood is this difference unexpected or something that should be looked at?