### PR TITLE
Ignore broken curl-config.cmake

### DIFF
--- a/libcurl_vendor/CMakeLists.txt
+++ b/libcurl_vendor/CMakeLists.txt
@@ -85,6 +85,7 @@ if(NOT CURL_FOUND)
     set(ENV_VAR_VALUE "opt/libcurl_vendor/lib")
   endif()
   ament_environment_hooks(env_hook/libcurl_vendor_library_path.dsv.in)
+  set(CURL_FOUND FALSE)
 endif()
 
 ament_package(

--- a/libcurl_vendor/libcurl_vendor-extras.cmake.in
+++ b/libcurl_vendor/libcurl_vendor-extras.cmake.in
@@ -1,3 +1,6 @@
+# Ignore the broken curl-config.cmake in 7.58
+set(CURL_NO_CURL_CMAKE ON)
+
 # Look for system curl first.
 find_package(CURL QUIET)
 

--- a/libcurl_vendor/libcurl_vendor-extras.cmake.in
+++ b/libcurl_vendor/libcurl_vendor-extras.cmake.in
@@ -1,5 +1,7 @@
 # Ignore the broken curl-config.cmake in 7.58
-set(CURL_NO_CURL_CMAKE ON)
+if(NOT @CURL_FOUND@)
+  set(CURL_NO_CURL_CMAKE ON)
+endif()
 
 # Look for system curl first.
 find_package(CURL QUIET)


### PR DESCRIPTION
This flag was introduced to maintain existing behavior in CMake 3.17 and newer, where FindCURL.cmake was changed to use curl-config.cmake if it is found.

It appears that the curl-config.cmake that comes with the current version of curl that this package includes does not work properly. Until we target a version of curl that has a working curl-config.cmake on Windows, we should continue with the CMake behavior prior to 3.17 by specifying CURL_NO_CURL_CMAKE.

Here is the change in CMake 3.17: https://github.com/Kitware/CMake/commit/c11e7c5c3d5c5e682adf761c4b0de734ff68e690

Alternative to #39
Closes #38