### PR TITLE
[Eloquent] Backport Ignore borken curl config

### DIFF
--- a/libcurl_vendor/CMakeLists.txt
+++ b/libcurl_vendor/CMakeLists.txt
@@ -85,6 +85,7 @@ if(NOT CURL_FOUND)
     set(ENV_VAR_VALUE "opt/libcurl_vendor/lib")
   endif()
   ament_environment_hooks(env_hook/libcurl_vendor_library_path.dsv.in)
+  set(CURL_FOUND FALSE)
 endif()
 
 ament_package(

--- a/libcurl_vendor/libcurl_vendor-extras.cmake.in
+++ b/libcurl_vendor/libcurl_vendor-extras.cmake.in
@@ -1,3 +1,8 @@
+# Ignore the broken curl-config.cmake in 7.58
+if(NOT @CURL_FOUND@)
+  set(CURL_NO_CURL_CMAKE ON)
+endif()
+
 # Look for system curl first.
 find_package(CURL QUIET)
 


### PR DESCRIPTION
Backport #40 due to a report that it also affects ROS Eloquent: https://answers.ros.org/question/347339/resource_retriever-package-doesnt-build-in-ros2-windows/