### PR TITLE
[ros2] Use pytest instead of nose

### DIFF
--- a/resource_retriever/package.xml
+++ b/resource_retriever/package.xml
@@ -31,6 +31,7 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>python3-pytest</test_depend>
   <test_depend>python_cmake_module</test_depend>
 
   <export>

--- a/resource_retriever/test/test.py
+++ b/resource_retriever/test/test.py
@@ -27,10 +27,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import ament_index_python
-
-from nose.tools import raises
-
 import resource_retriever as r
+import pytest
 
 
 def test_get_by_package():
@@ -44,16 +42,16 @@ def test_http():
     assert len(res) > 0
 
 
-@raises(Exception)
 def test_invalid_file():
-    r.get('file://fail')
+    with pytest.raises(Exception):
+        r.get('file://fail')
 
 
-@raises(Exception)
 def test_no_file():
-    r.get('package://roscpp')
+    with pytest.raises(Exception):
+        r.get('package://roscpp')
 
 
-@raises(ament_index_python.PackageNotFoundError)
 def test_invalid_package():
-    r.get('package://invalid_package_blah/test.xml')
+    with pytest.raises(ament_index_python.PackageNotFoundError):
+        r.get('package://invalid_package_blah/test.xml')


### PR DESCRIPTION
Should fix foxy dev job: http://build.ros2.org/job/Fdev__resource_retriever__ubuntu_focal_amd64/1/testReport/junit/(root)/resource_retriever/test_test/

```
ImportError while importing test module '/tmp/ws/src/resource_retriever/resource_retriever/test/test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../src/resource_retriever/resource_retriever/test/test.py:31: in <module>
    from nose.tools import raises
E   ModuleNotFoundError: No module named 'nose'
```