### PR TITLE
Import pytest before resource_retriever

### DIFF
--- a/resource_retriever/test/test.py
+++ b/resource_retriever/test/test.py
@@ -27,8 +27,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import ament_index_python
-import resource_retriever as r
 import pytest
+import resource_retriever as r
 
 
 def test_get_by_package():


### PR DESCRIPTION
Fix flake8 failure https://ci.ros2.org/view/All/job/test_ci_osx/320/testReport/junit/resource_retriever/flake8/I100____test_test_py_31_1_/

Guess the PR job doesn't do flake8 testing, or it's missing flake8 plugins :(