### PR TITLE
[Dashing] Ignore broken curl-config.cmake (#40)

### DIFF
--- a/libcurl_vendor/CMakeLists.txt
+++ b/libcurl_vendor/CMakeLists.txt
@@ -76,6 +76,7 @@ if(NOT CURL_FOUND)
   else()
     ament_environment_hooks(env_hook/libcurl_vendor_library_path.sh)
   endif()
+  set(CURL_FOUND FALSE)
 endif()
 
 ament_package(

--- a/libcurl_vendor/libcurl_vendor-extras.cmake.in
+++ b/libcurl_vendor/libcurl_vendor-extras.cmake.in
@@ -1,3 +1,8 @@
+# Ignore the broken curl-config.cmake in 7.58
+if(NOT @CURL_FOUND@)
+  set(CURL_NO_CURL_CMAKE ON)
+endif()
+
 # Look for system curl first.
 find_package(CURL QUIET)
 


### PR DESCRIPTION
This backports #40 into Dashing to fix builds on Windows.