### PR TITLE
Add resolve() for getting local paths

### DIFF
--- a/resource_retriever/include/resource_retriever/retriever.hpp
+++ b/resource_retriever/include/resource_retriever/retriever.hpp
@@ -82,6 +82,14 @@ public:
    */
   MemoryResource get(const std::string & url);
 
+  /**
+   * \brief Resolve the URL to a file on disk
+   * \param url The url to resolve to a local path on disk
+   * \return The path on disk if the url resolves to a local path, else empty string
+   * \throws resource_retriever::Exception if anything goes wrong.
+   */
+  std::string resolve(const std::string & url);
+
 private:
   Retriever(const Retriever & ret) = delete;
 

--- a/resource_retriever/src/retriever.cpp
+++ b/resource_retriever/src/retriever.cpp
@@ -94,10 +94,10 @@ size_t curlWriteFunc(void * buffer, size_t size, size_t nmemb, void * userp)
   return size * nmemb;
 }
 
-MemoryResource Retriever::get(const std::string & url)
+std::string Retriever::resolve(const std::string & url)
 {
-  std::string mod_url = url;
   if (url.find("package://") == 0) {
+    std::string mod_url = url;
     mod_url.erase(0, strlen("package://"));
     size_t pos = mod_url.find("/");
     if (pos == std::string::npos) {
@@ -113,7 +113,21 @@ MemoryResource Retriever::get(const std::string & url)
       throw Exception(url, "Package [" + package + "] does not exist");
     }
 
-    mod_url = "file://" + package_path + mod_url;
+    return package_path + mod_url;
+  }
+  else if (url.find("file://") == 0) {
+    return url.substr(strlen("file://"));
+  }
+
+  return "";
+}
+
+MemoryResource Retriever::get(const std::string & url)
+{
+  std::string mod_url = url;
+  std::string local_path = resolve(url);
+  if (!local_path.empty()) {
+    mod_url = "file://" + local_path;
   }
 
   curl_easy_setopt(curl_handle_, CURLOPT_URL, mod_url.c_str());


### PR DESCRIPTION
This PR adds a method `resolve()` which turns a URI into a local path - if possible. It's intended to support https://github.com/ros/sdformat_urdf/pull/1