### PR TITLE
[foxy backport] Add pytest.ini so local tests don't display warning (#48)

### DIFF
--- a/resource_retriever/pytest.ini
+++ b/resource_retriever/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
Backport #48 to Foxy.

This should help resolve one of the outstanding failures in ros2/ci#503