### PR TITLE
Throw exception if package name is empty

### DIFF
--- a/resource_retriever/src/retriever.cpp
+++ b/resource_retriever/src/retriever.cpp
@@ -105,6 +105,9 @@ MemoryResource Retriever::get(const std::string & url)
     }
 
     std::string package = mod_url.substr(0, pos);
+    if (package.empty()) {
+      throw Exception(url, "Package name must not be empty");
+    }
     mod_url.erase(0, pos);
     std::string package_path;
     try {

--- a/resource_retriever/test/test.cpp
+++ b/resource_retriever/test/test.cpp
@@ -82,6 +82,14 @@ TEST(Retriever, invalidFiles)
   } catch (const std::exception & e) {
     (void)e;
   }
+
+  // Empty package name
+  try {
+    r.get("package:///test.xml");
+    FAIL();
+  } catch (const std::exception & e) {
+    (void)e;
+  }
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Otherwise, ament_index_cpp will throw a std::runtime_error.
Throwing an exception from resource_retriever instead makes for a more useful error message.