### PR TITLE
Add an override flag to force vendored build

### DIFF
--- a/libcurl_vendor/CMakeLists.txt
+++ b/libcurl_vendor/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 
 project(libcurl_vendor)
 
+option(FORCE_BUILD_VENDOR_PKG
+  "Build libcurl from source, even if system-installed package is available"
+  OFF)
+
 find_package(ament_cmake REQUIRED)
 
 set(PACKAGE_VERSION "1.0.0")
@@ -67,7 +71,7 @@ endmacro()
 
 find_package(CURL QUIET)
 
-if(NOT CURL_FOUND)
+if(FORCE_BUILD_VENDOR_PKG OR NOT CURL_FOUND)
   # System curl not found, build one locally.
   build_libcurl()
 


### PR DESCRIPTION
Nearly all of the other ROS 2 vendor packages in the critical path to the desktop variant support this flag, which can be very useful in testing.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13585)](http://ci.ros2.org/job/ci_linux/13585/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8473)](http://ci.ros2.org/job/ci_linux-aarch64/8473/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11303)](http://ci.ros2.org/job/ci_osx/11303/) <-- Test failures are in the [nightly build, too](https://ci.ros2.org/view/nightly/job/nightly_osx_repeated/2238/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13647)](http://ci.ros2.org/job/ci_windows/13647/)

With the new flag specified:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13586)](http://ci.ros2.org/job/ci_linux/13586/)