### PR TITLE
Split curl dependency to avoid dev package at runtime

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,11 +27,13 @@
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
-  <depend>curl</depend>
+  <build_depend>libcurl-dev</build_depend>
+
   <depend>roslib</depend>
   <depend>rosconsole</depend>
   <depend>boost</depend>
 
+  <exec_depend>libcurl</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>
 


### PR DESCRIPTION
The rosdep keys were (recently) added in ros/rosdistro#31301.

From what I can tell, the curl headers are not needed by packages building against this package, so `libcurl-dev` doesn't need to be a `build_export_depend`.