### PR TITLE
Windows curl dir fix

### DIFF
--- a/libcurl_vendor/libcurl_vendor-extras.cmake.in
+++ b/libcurl_vendor/libcurl_vendor-extras.cmake.in
@@ -10,7 +10,7 @@ find_package(CURL QUIET)
 if(NOT CURL_FOUND)
   if(WIN32)
     # Force cmake to find the curl-config file in our local build.
-    set(curl_DIR "${@PROJECT_NAME@_DIR}/../../../opt/libcurl_vendor/CMake")
+    set(curl_DIR "${@PROJECT_NAME@_DIR}/../../../opt/libcurl_vendor/lib/cmake/CURL")
     message(STATUS "Setting curl_DIR to: '${curl_DIR}'")
 
     find_package(curl REQUIRED PATHS "${curl_DIR}" NO_MODULE NO_DEFAULT_PATH)


### PR DESCRIPTION
Found out that `curl_DIR` set up in `libcurl_vendor-extras.cmake` doesn't exist in Windows environment. This PR changes this path to an existing one. 

Fixes #75 