### PR TITLE
fix build if no gtest is installed

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 
 catkin_add_gtest(${PROJECT_NAME}_utest test.cpp)
-target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME})
+if(TARGET ${PROJECT_NAME}_utest)
+  target_link_libraries(${PROJECT_NAME}_utest ${PROJECT_NAME})
+endif()
 
 catkin_add_nosetests(test.py)


### PR DESCRIPTION
`catkin_add_gtest` will not define a target if `gtest` is not installed,
but not fail the compile.
Unfortunately the `target_link_libraries` will then fail the build, i.e:
```
CMake Warning at /home/dreuter/ros/noetic/install_isolated/share/catkin/cmake/test/gtest.cmake:160 (message):
  skipping gtest 'resource_retriever_utest' in project 'resource_retriever'
  because gtest was not found
Call Stack (most recent call first):
  /home/dreuter/ros/noetic/install_isolated/share/catkin/cmake/test/gtest.cmake:89 (_catkin_add_executable_with_google_test)
  /home/dreuter/ros/noetic/install_isolated/share/catkin/cmake/test/gtest.cmake:37 (_catkin_add_google_test)
  test/CMakeLists.txt:3 (catkin_add_gtest)


CMake Error at test/CMakeLists.txt:4 (target_link_libraries):
  Cannot specify link libraries for target "resource_retriever_utest" which
  is not built by this project.
```

By checking if the target exists before calling `target_link_libraries`,
we can restore the intended behavior of `catkin_add_gtest` to "silently"
fail.