### PR TITLE
Fixes policy CMP0135 warning for CMake >= 3.24

### DIFF
--- a/libcurl_vendor/CMakeLists.txt
+++ b/libcurl_vendor/CMakeLists.txt
@@ -8,6 +8,11 @@ option(FORCE_BUILD_VENDOR_PKG
 
 find_package(ament_cmake REQUIRED)
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
+if (POLICY CMP0135)
+  cmake_policy(SET CMP0135 OLD)
+endif()
+
 macro(build_libcurl)
   set(extra_cxx_flags)
   set(extra_c_flags)


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

Reference build: https://ci.ros2.org/view/nightly/job/nightly_win_deb/2473/

[This](https://cmake.org/cmake/help/latest/policy/CMP0135.html) warning started appearing on new windows machines. It’s caused by a new CMake version (3.24) that expects this policy to be set.

This PR sets CMP0135 policy in CMakeLists.txt

CI launch:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17256)](http://ci.ros2.org/job/ci_linux/17256/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11795)](http://ci.ros2.org/job/ci_linux-aarch64/11795/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17736)](http://ci.ros2.org/job/ci_windows/17736/)