### PR TITLE
Sets CMP0135 policy behavior to NEW

### DIFF
--- a/libcurl_vendor/CMakeLists.txt
+++ b/libcurl_vendor/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(ament_cmake REQUIRED)
 
 # Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
 if (POLICY CMP0135)
-  cmake_policy(SET CMP0135 OLD)
+  cmake_policy(SET CMP0135 NEW)
 endif()
 
 macro(build_libcurl)


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

https://github.com/ros2/rosbag2/pull/1084#pullrequestreview-1103004078 suggest changing the behavior from OLD to NEW. This PR does that for this package.

Ci_launch_test:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17272)](http://ci.ros2.org/job/ci_linux/17272/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11813)](http://ci.ros2.org/job/ci_linux-aarch64/11813/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17754)](http://ci.ros2.org/job/ci_windows/17754/)