### PR TITLE
merge libcurl_vendor build instructions

### DIFF
--- a/libcurl_vendor/CMakeLists.txt
+++ b/libcurl_vendor/CMakeLists.txt
@@ -39,7 +39,7 @@ macro(build_libcurl)
       -DBUILD_TESTING=OFF
       -DCURL_ENABLE_SSL=ON  # default, but just to make clear
       -DUSE_LIBIDN2=OFF
-      -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/opt/libcurl_vendor
     TIMEOUT 600
   )
 endmacro()

--- a/libcurl_vendor/CMakeLists.txt
+++ b/libcurl_vendor/CMakeLists.txt
@@ -14,16 +14,12 @@ if (POLICY CMP0135)
 endif()
 
 macro(build_libcurl)
+
   set(extra_cxx_flags)
   set(extra_c_flags)
   if(NOT WIN32)
-    list(APPEND extra_cxx_flags "-std=c++14 -w")
+    list(APPEND extra_cxx_flags "-w")
     list(APPEND extra_c_flags "-w")
-  endif()
-
-  set(PKGCONFIG_FOR_OPENSSL)
-  if(APPLE)
-    set(PKGCONFIG_FOR_OPENSSL "/usr/local/opt/openssl/lib/pkgconfig")
   endif()
 
   if(WIN32 AND NOT ${CMAKE_VERBOSE_MAKEFILE})
@@ -33,38 +29,25 @@ macro(build_libcurl)
   endif()
 
   include(ExternalProject)
-  if(WIN32)
-    ExternalProject_Add(curl-7.81.0
-      URL https://github.com/curl/curl/releases/download/curl-7_81_0/curl-7.81.0.tar.gz
-      URL_MD5 9e5e81fc7657eea8dc66672768082c46
-      LOG_CONFIGURE ${should_log}
-      LOG_BUILD ${should_log}
-      CMAKE_ARGS
-        -DENABLE_MANUAL=OFF
-        -DBUILD_TESTING=OFF
-        -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libcurl_install
-        -Wno-dev
-      TIMEOUT 600
-    )
-  else()
-    ExternalProject_Add(curl-7.81.0
-      URL https://github.com/curl/curl/releases/download/curl-7_81_0/curl-7.81.0.tar.gz
-      URL_MD5 9e5e81fc7657eea8dc66672768082c46
-      CONFIGURE_COMMAND
-        <SOURCE_DIR>/configure
-        CFLAGS=${extra_c_flags}
-        CXXFLAGS=${extra_cxx_flags}
-        PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${PKGCONFIG_FOR_OPENSSL}
-        --prefix=${CMAKE_CURRENT_BINARY_DIR}/libcurl_install
-        --with-ssl
-        --without-libgsasl
-        --without-libpsl
-        --without-libidn2
-      BUILD_COMMAND $(MAKE)
-      INSTALL_COMMAND $(MAKE) install
-      TIMEOUT 600
-    )
-  endif()
+
+  ExternalProject_Add(curl-7.81.0
+    URL https://github.com/curl/curl/releases/download/curl-7_81_0/curl-7.81.0.tar.gz
+    URL_MD5 9e5e81fc7657eea8dc66672768082c46
+    LOG_CONFIGURE ${should_log}
+    LOG_BUILD ${should_log}
+    CMAKE_ARGS
+      -DCMAKE_CXX_STANDARD=14
+      -DCMAKE_CXX_FLAGS=${extra_cxx_flags}
+      -DCMAKE_C_FLAGS=${extra_c_flags}
+      -DENABLE_MANUAL=OFF
+      -DBUILD_TESTING=OFF
+      -DCURL_ENABLE_SSL=ON #default, but just to make clear
+      -DCURL_USE_LIBPSL=OFF
+      -DUSE_LIBIDN2=OFF
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libcurl_install
+      -Wno-dev
+    TIMEOUT 600
+  )
 
   # The external project will install to the build folder, but we'll install that on make install.
   install(

--- a/libcurl_vendor/CMakeLists.txt
+++ b/libcurl_vendor/CMakeLists.txt
@@ -38,10 +38,10 @@ macro(build_libcurl)
       -DENABLE_MANUAL=OFF
       -DBUILD_TESTING=OFF
       -DCURL_ENABLE_SSL=ON  # default, but just to make clear
+      -DUSE_LIBIDN2=OFF
       -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
     TIMEOUT 600
   )
-
 endmacro()
 
 find_package(CURL QUIET)

--- a/libcurl_vendor/CMakeLists.txt
+++ b/libcurl_vendor/CMakeLists.txt
@@ -39,8 +39,16 @@ macro(build_libcurl)
       -DBUILD_TESTING=OFF
       -DCURL_ENABLE_SSL=ON  # default, but just to make clear
       -DUSE_LIBIDN2=OFF
-      -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/opt/libcurl_vendor
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libcurl_install
     TIMEOUT 600
+  )
+
+  # The external project will install to the build folder, but we'll install that on make install.
+  install(
+    DIRECTORY
+      ${CMAKE_CURRENT_BINARY_DIR}/libcurl_install/
+    DESTINATION
+      ${CMAKE_INSTALL_PREFIX}/opt/libcurl_vendor
   )
 endmacro()
 

--- a/libcurl_vendor/CMakeLists.txt
+++ b/libcurl_vendor/CMakeLists.txt
@@ -15,10 +15,8 @@ endif()
 
 macro(build_libcurl)
 
-  set(extra_cxx_flags)
   set(extra_c_flags)
   if(NOT WIN32)
-    list(APPEND extra_cxx_flags "-w")
     list(APPEND extra_c_flags "-w")
   endif()
 
@@ -36,26 +34,14 @@ macro(build_libcurl)
     LOG_CONFIGURE ${should_log}
     LOG_BUILD ${should_log}
     CMAKE_ARGS
-      -DCMAKE_CXX_STANDARD=14
-      -DCMAKE_CXX_FLAGS=${extra_cxx_flags}
       -DCMAKE_C_FLAGS=${extra_c_flags}
       -DENABLE_MANUAL=OFF
       -DBUILD_TESTING=OFF
-      -DCURL_ENABLE_SSL=ON #default, but just to make clear
-      -DCURL_USE_LIBPSL=OFF
-      -DUSE_LIBIDN2=OFF
-      -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libcurl_install
-      -Wno-dev
+      -DCURL_ENABLE_SSL=ON  # default, but just to make clear
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
     TIMEOUT 600
   )
 
-  # The external project will install to the build folder, but we'll install that on make install.
-  install(
-    DIRECTORY
-      ${CMAKE_CURRENT_BINARY_DIR}/libcurl_install/
-    DESTINATION
-      ${CMAKE_INSTALL_PREFIX}/opt/libcurl_vendor
-  )
 endmacro()
 
 find_package(CURL QUIET)


### PR DESCRIPTION
I tested these changes on the galactic branch on ubuntu 18.04 and they worked fine.  I'm not able to test them on windows or apple. I'm not a fan of pushing in `CMAKE_CXX_FLAGS` like I am, but am not sure how to otherwise do it. 