### PR TITLE
Make importing the library fast

### DIFF
--- a/src/resource_retriever/__init__.py
+++ b/src/resource_retriever/__init__.py
@@ -41,7 +41,15 @@ except ImportError:
     from urllib2 import URLError
 
 PACKAGE_PREFIX = 'package://'
-r = rospkg.RosPack()
+_rospack = None
+
+
+def get_rospack():
+    global _rospack
+    if _rospack is None:
+        _rospack = rospkg.RosPack()
+    return _rospack
+
 
 def get_filename(url, use_protocol=True):
     mod_url = url
@@ -53,7 +61,7 @@ def get_filename(url, use_protocol=True):
 
         package = mod_url[0:pos]
         mod_url = mod_url[pos:]
-        package_path = r.get_path(package)
+        package_path = get_rospack().get_path(package)
 
         if use_protocol:
             protocol = "file://"

--- a/src/resource_retriever/__init__.py
+++ b/src/resource_retriever/__init__.py
@@ -31,7 +31,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-import roslib; roslib.load_manifest('resource_retriever')
 import subprocess
 import rospkg
 try:


### PR DESCRIPTION
`import resource_retriever` is now slow due to the `roslib.load_manifest` and instantiation of `rospkg.RosPack` on import time.
In this PR,
1. Removed the `roslib.load_manifest` as it is not necessary on the latest ROS distribution
2. Delay instantiation of `rospkg.RosPack` object to right before the object is used.

![](https://user-images.githubusercontent.com/1901008/231002067-aff2bf8f-258a-4baf-8cfd-3d3606ca1702.png)