### PR TITLE
Switch to target_link_libraries.

### DIFF
--- a/resource_retriever/CMakeLists.txt
+++ b/resource_retriever/CMakeLists.txt
@@ -7,14 +7,14 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
-if(NOT WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake_ros REQUIRED)
 find_package(ament_index_cpp REQUIRED)
-# TODO(wjwwood): remove libcurl_vendor and just use system curl when possible
 find_package(libcurl_vendor REQUIRED)
+find_package(CURL REQUIRED)
 
 # TODO(wjwwood): split cpp and python apis into separate packages
 
@@ -24,10 +24,11 @@ target_include_directories(${PROJECT_NAME}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
-ament_target_dependencies(${PROJECT_NAME}
-  ament_index_cpp
-  libcurl_vendor
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  ament_index_cpp::ament_index_cpp
+  CURL::libcurl
 )
+
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RESOURCE_RETRIEVER_BUILDING_LIBRARY")
@@ -37,10 +38,6 @@ ament_export_include_directories("include/${PROJECT_NAME}")
 
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
-
-# specific order: dependents before dependencies
-ament_export_dependencies(ament_index_cpp)
-ament_export_dependencies(libcurl_vendor)
 
 ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR src/${PROJECT_NAME})


### PR DESCRIPTION
This allows us to mark libraries as PRIVATE, so we can export less to downstream consumers.