### PR TITLE
Stop using python_cmake_module.

### DIFF
--- a/resource_retriever/CMakeLists.txt
+++ b/resource_retriever/CMakeLists.txt
@@ -58,24 +58,11 @@ if(BUILD_TESTING)
   ament_add_gtest(${PROJECT_NAME}_test test/test.cpp)
   target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME})
 
-  # Python test
-  # Provides PYTHON_EXECUTABLE_DEBUG
-  find_package(python_cmake_module REQUIRED)
-  find_package(PythonExtra REQUIRED)
-
-  set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
-  if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-  endif()
-
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(resource_retriever_python_test test/test.py
-    PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}"
     APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
     TIMEOUT 60
   )
-
-  set(PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")
 
   install(
     FILES test/test.txt

--- a/resource_retriever/package.xml
+++ b/resource_retriever/package.xml
@@ -34,7 +34,6 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>python_cmake_module</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
We really don't need it anymore, and can just use the builtin find_package(Python3).

This must be merged before https://github.com/ros2/ros2/pull/1524 ; see that pull request for more information about this change.