### PR TITLE
Add "lib" to the Windows curl search path.

### DIFF
--- a/libcurl_vendor/libcurl_vendor-extras.cmake.in
+++ b/libcurl_vendor/libcurl_vendor-extras.cmake.in
@@ -10,7 +10,7 @@ find_package(CURL QUIET)
 if(NOT CURL_FOUND)
   if(WIN32)
     # Force cmake to find the curl-config file in our local build.
-    set(curl_DIR "${@PROJECT_NAME@_DIR}/../../../opt/libcurl_vendor/CMake")
+    set(curl_DIR "${@PROJECT_NAME@_DIR}/../../../opt/libcurl_vendor/lib/CMake")
     message(STATUS "Setting curl_DIR to: '${curl_DIR}'")
 
     find_package(curl REQUIRED PATHS "${curl_DIR}" NO_MODULE NO_DEFAULT_PATH)


### PR DESCRIPTION
In CMake 3.3, a commit made it so that the find_package module in CMake had a compatibility mode where it would automatically search for packages in a <prefix>/lib subdirectory. In CMake 3.6, this compatibility mode was reverted for all platforms *except* Windows.

That means that since CMake 3.3, we haven't actually been using the path as specified in `curl_DIR`, but we have instead been inadvertently relying on that fallback behavior.

In CMake 3.28, that compatibilty mode was also removed for Windows, meaning that we are now failing to find_package(curl) in downstream packages (like resource_retriever).

Fix this by adding in the "lib" directory that always should have been there.  I'll note that this *only* affects our Windows builds, because this code is in a if(WIN32) block.

---

The commit to CMake that caused this is https://github.com/Kitware/CMake/commit/0a81110b842fd7b00cdacc55c270458ddaa2eb73

I'll note that this one is kind of hard to test; just running CI on this won't show us succeeding before and after.  I will say that in local testing, where I've upgraded my CMake to 3.29.2 on Windows, this fixes the issue for me.  And of course I'll run CI on it just to make sure there are no ill effects on earlier CMake versions.