### PR TITLE
Use CURL::libcurl instead of ${CURL_LIBRARIES}  in cmakelists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ catkin_package(
   INCLUDE_DIRS include)
 
 add_library(${PROJECT_NAME} src/retriever.cpp)
-target_link_libraries(${PROJECT_NAME} ${CURL_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} CURL::libcurl ${catkin_LIBRARIES})
 
 if(CATKIN_ENABLE_TESTING)
   add_subdirectory(test EXCLUDE_FROM_ALL)


### PR DESCRIPTION
`${CURL_LIBRARIES}` wasn't working for me with `/usr/share/cmake-3.28/Modules/FindCURL.cmake` from cmake-data 3.28.3-1build7, I can look into it further and see how backwards compatible CURL::libcurl is.