### PR TITLE
Add a plugin mechanism to resource_retriever

### DIFF
--- a/resource_retriever/CMakeLists.txt
+++ b/resource_retriever/CMakeLists.txt
@@ -17,8 +17,12 @@ find_package(libcurl_vendor REQUIRED)
 find_package(CURL REQUIRED)
 
 # TODO(wjwwood): split cpp and python apis into separate packages
-
-add_library(${PROJECT_NAME} src/retriever.cpp)
+add_library(${PROJECT_NAME}
+  src/retriever.cpp
+  src/plugins/retriever_plugin.cpp
+  src/plugins/filesystem_retriever.cpp
+  src/plugins/curl_retriever.cpp
+)
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/resource_retriever/include/resource_retriever/exception.hpp
+++ b/resource_retriever/include/resource_retriever/exception.hpp
@@ -26,50 +26,24 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "resource_retriever/retriever.hpp"
+#ifndef RESOURCE_RETRIEVER__EXCEPTION_HPP_
+#define RESOURCE_RETRIEVER__EXCEPTION_HPP_
 
-#include <cstring>
-#include <memory>
+#include <stdexcept>
 #include <string>
-#include <utility>
-#include <vector>
 
-#include "resource_retriever/exception.hpp"
-#include "resource_retriever/plugins/curl_retriever.hpp"
-#include "resource_retriever/plugins/filesystem_retriever.hpp"
-
+#include "resource_retriever/visibility_control.hpp"
 
 namespace resource_retriever
 {
-
-RetrieverVec default_plugins()
+class RESOURCE_RETRIEVER_PUBLIC Exception : public std::runtime_error
 {
-  return {
-    std::make_shared<plugins::FilesystemRetriever>(),
-    std::make_shared<plugins::CurlRetriever>(),
-  };
-}
-
-Retriever::Retriever(RetrieverVec plugins):
-  plugins(std::move(plugins))
-{
-}
-
-Retriever::~Retriever() = default;
-
-MemoryResourcePtr Retriever::get(const std::string & url)
-{
-  for (auto & plugin : plugins)
+public:
+  Exception(const std::string & file, const std::string & error_msg)
+  : std::runtime_error("Error retrieving file [" + file + "]: " + error_msg)
   {
-    if (plugin->can_handle(url))
-    {
-      auto res = plugin->get(url);
-
-      if (res != nullptr)
-        return res;
-    }
   }
-  return nullptr;
-}
-
+};
 }  // namespace resource_retriever
+
+#endif  // RESOURCE_RETRIEVER__EXCEPTION_HPP_

--- a/resource_retriever/include/resource_retriever/exception.hpp
+++ b/resource_retriever/include/resource_retriever/exception.hpp
@@ -1,4 +1,5 @@
 // Copyright 2009, Willow Garage, Inc. All rights reserved.
+// Copyright 2025 Open Source Robotics Foundation, Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:

--- a/resource_retriever/include/resource_retriever/memory_resource.hpp
+++ b/resource_retriever/include/resource_retriever/memory_resource.hpp
@@ -30,6 +30,7 @@
 #define RESOURCE_RETRIEVER__MEMORY_RESOURCE_HPP_
 
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -42,10 +43,14 @@ namespace resource_retriever
  */
 struct RESOURCE_RETRIEVER_PUBLIC MemoryResource
 {
-  explicit MemoryResource(std::vector<uint8_t> data):
+  explicit MemoryResource(std::string url, std::string expanded_url, std::vector<uint8_t> data):
+    url(std::move(url)),
+    expanded_url(std::move(expanded_url)),
     data(std::move(data))
   {
   }
+  const std::string url;
+  const std::string expanded_url;
   const std::vector<uint8_t> data;
 };
 

--- a/resource_retriever/include/resource_retriever/memory_resource.hpp
+++ b/resource_retriever/include/resource_retriever/memory_resource.hpp
@@ -26,50 +26,31 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "resource_retriever/retriever.hpp"
+#ifndef RESOURCE_RETRIEVER__MEMORY_RESOURCE_HPP_
+#define RESOURCE_RETRIEVER__MEMORY_RESOURCE_HPP_
 
-#include <cstring>
 #include <memory>
-#include <string>
 #include <utility>
 #include <vector>
 
-#include "resource_retriever/exception.hpp"
-#include "resource_retriever/plugins/curl_retriever.hpp"
-#include "resource_retriever/plugins/filesystem_retriever.hpp"
-
+#include "resource_retriever/visibility_control.hpp"
 
 namespace resource_retriever
 {
-
-RetrieverVec default_plugins()
+/**
+ * \brief A combination of a pointer to data in memory along with the data's size.
+ */
+struct RESOURCE_RETRIEVER_PUBLIC MemoryResource
 {
-  return {
-    std::make_shared<plugins::FilesystemRetriever>(),
-    std::make_shared<plugins::CurlRetriever>(),
-  };
-}
-
-Retriever::Retriever(RetrieverVec plugins):
-  plugins(std::move(plugins))
-{
-}
-
-Retriever::~Retriever() = default;
-
-MemoryResourcePtr Retriever::get(const std::string & url)
-{
-  for (auto & plugin : plugins)
+  explicit MemoryResource(std::vector<uint8_t> data):
+    data(std::move(data))
   {
-    if (plugin->can_handle(url))
-    {
-      auto res = plugin->get(url);
-
-      if (res != nullptr)
-        return res;
-    }
   }
-  return nullptr;
-}
+  const std::vector<uint8_t> data;
+};
 
-}  // namespace resource_retriever
+using MemoryResourcePtr = std::shared_ptr<MemoryResource>;
+
+}  //  namespace resource_retriever
+
+#endif  // RESOURCE_RETRIEVER__MEMORY_RESOURCE_HPP_

--- a/resource_retriever/include/resource_retriever/memory_resource.hpp
+++ b/resource_retriever/include/resource_retriever/memory_resource.hpp
@@ -42,23 +42,31 @@ namespace resource_retriever
 /**
  * \brief A combination of a pointer to data in memory along with the data's size.
  */
-struct RESOURCE_RETRIEVER_PUBLIC MemoryResource
+struct
+[[deprecated("use resource_retriever::Resource")]]
+RESOURCE_RETRIEVER_PUBLIC
+MemoryResource
 {
-  explicit MemoryResource(
-    std::string url_in,
-    std::string expanded_url_in,
-    std::vector<uint8_t> data_in)
-  : url(std::move(url_in)),
-    expanded_url(std::move(expanded_url_in)),
-    data(std::move(data_in))
-  {
-  }
-  const std::string url;
-  const std::string expanded_url;
-  const std::vector<uint8_t> data;
+  std::shared_ptr<uint8_t> data;
+  size_t size {0};
 };
 
-using MemoryResourceSharedPtr = std::shared_ptr<MemoryResource>;
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+using MemoryResourceSharedPtr [[deprecated("use resource_retriever::ResourceSharedPtr")]] =
+  std::shared_ptr<MemoryResource>;
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
+#endif
 
 }  //  namespace resource_retriever
 

--- a/resource_retriever/include/resource_retriever/memory_resource.hpp
+++ b/resource_retriever/include/resource_retriever/memory_resource.hpp
@@ -43,8 +43,11 @@ namespace resource_retriever
  */
 struct RESOURCE_RETRIEVER_PUBLIC MemoryResource
 {
-  explicit MemoryResource(std::string url_in, std::string expanded_url_in, std::vector<uint8_t> data_in):
-    url(std::move(url_in)),
+  explicit MemoryResource(
+    std::string url_in,
+    std::string expanded_url_in,
+    std::vector<uint8_t> data_in)
+  :url(std::move(url_in)),
     expanded_url(std::move(expanded_url_in)),
     data(std::move(data_in))
   {

--- a/resource_retriever/include/resource_retriever/memory_resource.hpp
+++ b/resource_retriever/include/resource_retriever/memory_resource.hpp
@@ -29,6 +29,7 @@
 #ifndef RESOURCE_RETRIEVER__MEMORY_RESOURCE_HPP_
 #define RESOURCE_RETRIEVER__MEMORY_RESOURCE_HPP_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>

--- a/resource_retriever/include/resource_retriever/memory_resource.hpp
+++ b/resource_retriever/include/resource_retriever/memory_resource.hpp
@@ -43,7 +43,15 @@ namespace resource_retriever
  * \brief A combination of a pointer to data in memory along with the data's size.
  */
 struct
-[[deprecated("use resource_retriever::Resource")]]
+// Not using [[deprecated("use resource_retriever::Resource")]] here becuase of:
+//   https://github.com/ros/resource_retriever/pull/103#issuecomment-2718515266
+#if defined(_MSC_VER)
+__declspec(deprecated("use resource_retriever::Resource"))
+#elif defined(__GNUC__) || defined(__clang__)
+__attribute__((deprecated("use resource_retriever::Resource")))
+#else
+  // do nothing, no deprecated attribute
+#endif
 RESOURCE_RETRIEVER_PUBLIC
 MemoryResource
 {

--- a/resource_retriever/include/resource_retriever/memory_resource.hpp
+++ b/resource_retriever/include/resource_retriever/memory_resource.hpp
@@ -57,7 +57,7 @@ struct RESOURCE_RETRIEVER_PUBLIC MemoryResource
   const std::vector<uint8_t> data;
 };
 
-using MemoryResourcePtr = std::shared_ptr<MemoryResource>;
+using MemoryResourceSharedPtr = std::shared_ptr<MemoryResource>;
 
 }  //  namespace resource_retriever
 

--- a/resource_retriever/include/resource_retriever/memory_resource.hpp
+++ b/resource_retriever/include/resource_retriever/memory_resource.hpp
@@ -43,10 +43,10 @@ namespace resource_retriever
  */
 struct RESOURCE_RETRIEVER_PUBLIC MemoryResource
 {
-  explicit MemoryResource(std::string url, std::string expanded_url, std::vector<uint8_t> data):
-    url(std::move(url)),
-    expanded_url(std::move(expanded_url)),
-    data(std::move(data))
+  explicit MemoryResource(std::string url_in, std::string expanded_url_in, std::vector<uint8_t> data_in):
+    url(std::move(url_in)),
+    expanded_url(std::move(expanded_url_in)),
+    data(std::move(data_in))
   {
   }
   const std::string url;

--- a/resource_retriever/include/resource_retriever/memory_resource.hpp
+++ b/resource_retriever/include/resource_retriever/memory_resource.hpp
@@ -47,7 +47,7 @@ struct RESOURCE_RETRIEVER_PUBLIC MemoryResource
     std::string url_in,
     std::string expanded_url_in,
     std::vector<uint8_t> data_in)
-  :url(std::move(url_in)),
+  : url(std::move(url_in)),
     expanded_url(std::move(expanded_url_in)),
     data(std::move(data_in))
   {

--- a/resource_retriever/include/resource_retriever/plugins/curl_retriever.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/curl_retriever.hpp
@@ -29,12 +29,6 @@
 #ifndef RESOURCE_RETRIEVER__PLUGINS__CURL_RETRIEVER_HPP_
 #define RESOURCE_RETRIEVER__PLUGINS__CURL_RETRIEVER_HPP_
 
-#include <cstdint>
-#include <memory>
-#include <stdexcept>
-#include <string>
-#include <vector>
-
 #include "resource_retriever/plugins/retriever_plugin.hpp"
 #include "resource_retriever/visibility_control.hpp"
 

--- a/resource_retriever/include/resource_retriever/plugins/curl_retriever.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/curl_retriever.hpp
@@ -26,50 +26,43 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "resource_retriever/retriever.hpp"
+#ifndef RESOURCE_RETRIEVER__PLUGINS__CURL_RETRIEVER_HPP_
+#define RESOURCE_RETRIEVER__PLUGINS__CURL_RETRIEVER_HPP_
 
-#include <cstring>
+#include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <string>
-#include <utility>
 #include <vector>
 
-#include "resource_retriever/exception.hpp"
-#include "resource_retriever/plugins/curl_retriever.hpp"
-#include "resource_retriever/plugins/filesystem_retriever.hpp"
+#include "resource_retriever/plugins/retriever_plugin.hpp"
+#include "resource_retriever/visibility_control.hpp"
 
+using CURL = void;
 
-namespace resource_retriever
+namespace resource_retriever::plugins
 {
 
-RetrieverVec default_plugins()
+class RESOURCE_RETRIEVER_PUBLIC CurlRetriever: public RetrieverPlugin
 {
-  return {
-    std::make_shared<plugins::FilesystemRetriever>(),
-    std::make_shared<plugins::CurlRetriever>(),
-  };
-}
+public:
+  CurlRetriever();
+  ~CurlRetriever() override;
 
-Retriever::Retriever(RetrieverVec plugins):
-  plugins(std::move(plugins))
-{
-}
+  CurlRetriever(const CurlRetriever & ret) = delete;
+  CurlRetriever & operator=(const CurlRetriever & other) = delete;
 
-Retriever::~Retriever() = default;
+  CurlRetriever(CurlRetriever && other) noexcept;
+  CurlRetriever & operator=(CurlRetriever && other) noexcept;
 
-MemoryResourcePtr Retriever::get(const std::string & url)
-{
-  for (auto & plugin : plugins)
-  {
-    if (plugin->can_handle(url))
-    {
-      auto res = plugin->get(url);
+  bool can_handle(const std::string & url) override;
+  std::string name() override;
+  MemoryResourcePtr get(const std::string & url) override;
 
-      if (res != nullptr)
-        return res;
-    }
-  }
-  return nullptr;
-}
+private:
+  CURL * curl_handle_ {nullptr};
+};
 
-}  // namespace resource_retriever
+}  //  namespace resource_retriever::plugins
+
+#endif  // RESOURCE_RETRIEVER__PLUGINS__CURL_RETRIEVER_HPP_

--- a/resource_retriever/include/resource_retriever/plugins/curl_retriever.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/curl_retriever.hpp
@@ -57,7 +57,7 @@ public:
 
   bool can_handle(const std::string & url) override;
   std::string name() override;
-  MemoryResourceSharedPtr get_shared(const std::string & url) override;
+  ResourceSharedPtr get_shared(const std::string & url) override;
 
 private:
   CURL * curl_handle_ {nullptr};

--- a/resource_retriever/include/resource_retriever/plugins/curl_retriever.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/curl_retriever.hpp
@@ -42,6 +42,10 @@ namespace resource_retriever::plugins
 class RESOURCE_RETRIEVER_PUBLIC CurlRetriever : public RetrieverPlugin
 {
 public:
+  /// Construct a CurlRetriever plugin and initialize libcurl.
+  /**
+   * \throws std::runtime_error if libcurl fails to initialize
+   */
   CurlRetriever();
   ~CurlRetriever() override;
 

--- a/resource_retriever/include/resource_retriever/plugins/curl_retriever.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/curl_retriever.hpp
@@ -29,6 +29,8 @@
 #ifndef RESOURCE_RETRIEVER__PLUGINS__CURL_RETRIEVER_HPP_
 #define RESOURCE_RETRIEVER__PLUGINS__CURL_RETRIEVER_HPP_
 
+#include <string>
+
 #include "resource_retriever/plugins/retriever_plugin.hpp"
 #include "resource_retriever/visibility_control.hpp"
 
@@ -37,7 +39,7 @@ using CURL = void;
 namespace resource_retriever::plugins
 {
 
-class RESOURCE_RETRIEVER_PUBLIC CurlRetriever: public RetrieverPlugin
+class RESOURCE_RETRIEVER_PUBLIC CurlRetriever : public RetrieverPlugin
 {
 public:
   CurlRetriever();

--- a/resource_retriever/include/resource_retriever/plugins/curl_retriever.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/curl_retriever.hpp
@@ -57,7 +57,7 @@ public:
 
   bool can_handle(const std::string & url) override;
   std::string name() override;
-  MemoryResourcePtr get(const std::string & url) override;
+  MemoryResourceSharedPtr get_shared(const std::string & url) override;
 
 private:
   CURL * curl_handle_ {nullptr};

--- a/resource_retriever/include/resource_retriever/plugins/filesystem_retriever.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/filesystem_retriever.hpp
@@ -29,12 +29,6 @@
 #ifndef RESOURCE_RETRIEVER__PLUGINS__FILESYSTEM_RETRIEVER_HPP_
 #define RESOURCE_RETRIEVER__PLUGINS__FILESYSTEM_RETRIEVER_HPP_
 
-#include <cstdint>
-#include <memory>
-#include <stdexcept>
-#include <string>
-#include <vector>
-
 #include "resource_retriever/plugins/retriever_plugin.hpp"
 #include "resource_retriever/visibility_control.hpp"
 

--- a/resource_retriever/include/resource_retriever/plugins/filesystem_retriever.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/filesystem_retriever.hpp
@@ -26,50 +26,32 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "resource_retriever/retriever.hpp"
+#ifndef RESOURCE_RETRIEVER__PLUGINS__FILESYSTEM_RETRIEVER_HPP_
+#define RESOURCE_RETRIEVER__PLUGINS__FILESYSTEM_RETRIEVER_HPP_
 
-#include <cstring>
+#include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <string>
-#include <utility>
 #include <vector>
 
-#include "resource_retriever/exception.hpp"
-#include "resource_retriever/plugins/curl_retriever.hpp"
-#include "resource_retriever/plugins/filesystem_retriever.hpp"
+#include "resource_retriever/plugins/retriever_plugin.hpp"
+#include "resource_retriever/visibility_control.hpp"
 
-
-namespace resource_retriever
+namespace resource_retriever::plugins
 {
 
-RetrieverVec default_plugins()
+class RESOURCE_RETRIEVER_PUBLIC FilesystemRetriever: public RetrieverPlugin
 {
-  return {
-    std::make_shared<plugins::FilesystemRetriever>(),
-    std::make_shared<plugins::CurlRetriever>(),
-  };
-}
+public:
+  FilesystemRetriever();
+  ~FilesystemRetriever() override;
 
-Retriever::Retriever(RetrieverVec plugins):
-  plugins(std::move(plugins))
-{
-}
+  bool can_handle(const std::string & url) override;
+  std::string name() override;
+  MemoryResourcePtr get(const std::string & url) override;
+};
 
-Retriever::~Retriever() = default;
+}  //  namespace resource_retriever::plugins
 
-MemoryResourcePtr Retriever::get(const std::string & url)
-{
-  for (auto & plugin : plugins)
-  {
-    if (plugin->can_handle(url))
-    {
-      auto res = plugin->get(url);
-
-      if (res != nullptr)
-        return res;
-    }
-  }
-  return nullptr;
-}
-
-}  // namespace resource_retriever
+#endif  // RESOURCE_RETRIEVER__PLUGINS__FILESYSTEM_RETRIEVER_HPP_

--- a/resource_retriever/include/resource_retriever/plugins/filesystem_retriever.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/filesystem_retriever.hpp
@@ -45,7 +45,7 @@ public:
 
   bool can_handle(const std::string & url) override;
   std::string name() override;
-  MemoryResourcePtr get(const std::string & url) override;
+  MemoryResourceSharedPtr get_shared(const std::string & url) override;
 };
 
 }  //  namespace resource_retriever::plugins

--- a/resource_retriever/include/resource_retriever/plugins/filesystem_retriever.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/filesystem_retriever.hpp
@@ -29,13 +29,15 @@
 #ifndef RESOURCE_RETRIEVER__PLUGINS__FILESYSTEM_RETRIEVER_HPP_
 #define RESOURCE_RETRIEVER__PLUGINS__FILESYSTEM_RETRIEVER_HPP_
 
+#include <string>
+
 #include "resource_retriever/plugins/retriever_plugin.hpp"
 #include "resource_retriever/visibility_control.hpp"
 
 namespace resource_retriever::plugins
 {
 
-class RESOURCE_RETRIEVER_PUBLIC FilesystemRetriever: public RetrieverPlugin
+class RESOURCE_RETRIEVER_PUBLIC FilesystemRetriever : public RetrieverPlugin
 {
 public:
   FilesystemRetriever();

--- a/resource_retriever/include/resource_retriever/plugins/retriever_plugin.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/retriever_plugin.hpp
@@ -26,50 +26,30 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "resource_retriever/retriever.hpp"
+#ifndef RESOURCE_RETRIEVER__PLUGINS__RETRIEVER_PLUGIN_HPP_
+#define RESOURCE_RETRIEVER__PLUGINS__RETRIEVER_PLUGIN_HPP_
 
-#include <cstring>
-#include <memory>
 #include <string>
-#include <utility>
-#include <vector>
 
-#include "resource_retriever/exception.hpp"
-#include "resource_retriever/plugins/curl_retriever.hpp"
-#include "resource_retriever/plugins/filesystem_retriever.hpp"
+#include <resource_retriever/memory_resource.hpp>
+#include "resource_retriever/visibility_control.hpp"
 
-
-namespace resource_retriever
+namespace resource_retriever::plugins
 {
+std::string expand_package_url(const std::string &  url);
+std::string escape_spaces(const std::string & url);
 
-RetrieverVec default_plugins()
+class RESOURCE_RETRIEVER_PUBLIC RetrieverPlugin
 {
-  return {
-    std::make_shared<plugins::FilesystemRetriever>(),
-    std::make_shared<plugins::CurlRetriever>(),
-  };
-}
+public:
+  RetrieverPlugin();
+  virtual ~RetrieverPlugin() = 0;
 
-Retriever::Retriever(RetrieverVec plugins):
-  plugins(std::move(plugins))
-{
-}
+  virtual std::string name() = 0;
+  virtual bool can_handle(const std::string & url) = 0;
+  virtual MemoryResourcePtr get(const std::string & url) = 0;
+};
 
-Retriever::~Retriever() = default;
+}  //  namespace resource_retriever::plugins
 
-MemoryResourcePtr Retriever::get(const std::string & url)
-{
-  for (auto & plugin : plugins)
-  {
-    if (plugin->can_handle(url))
-    {
-      auto res = plugin->get(url);
-
-      if (res != nullptr)
-        return res;
-    }
-  }
-  return nullptr;
-}
-
-}  // namespace resource_retriever
+#endif  // RESOURCE_RETRIEVER__PLUGINS__RETRIEVER_PLUGIN_HPP_

--- a/resource_retriever/include/resource_retriever/plugins/retriever_plugin.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/retriever_plugin.hpp
@@ -31,7 +31,7 @@
 
 #include <string>
 
-#include <resource_retriever/memory_resource.hpp>
+#include <resource_retriever/resource.hpp>
 #include "resource_retriever/visibility_control.hpp"
 
 namespace resource_retriever::plugins
@@ -47,7 +47,7 @@ public:
 
   virtual std::string name() = 0;
   virtual bool can_handle(const std::string & url) = 0;
-  virtual MemoryResourceSharedPtr get_shared(const std::string & url) = 0;
+  virtual ResourceSharedPtr get_shared(const std::string & url) = 0;
 };
 
 }  //  namespace resource_retriever::plugins

--- a/resource_retriever/include/resource_retriever/plugins/retriever_plugin.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/retriever_plugin.hpp
@@ -47,7 +47,7 @@ public:
 
   virtual std::string name() = 0;
   virtual bool can_handle(const std::string & url) = 0;
-  virtual MemoryResourcePtr get(const std::string & url) = 0;
+  virtual MemoryResourceSharedPtr get_shared(const std::string & url) = 0;
 };
 
 }  //  namespace resource_retriever::plugins

--- a/resource_retriever/include/resource_retriever/plugins/retriever_plugin.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/retriever_plugin.hpp
@@ -36,7 +36,7 @@
 
 namespace resource_retriever::plugins
 {
-std::string expand_package_url(const std::string &  url);
+std::string expand_package_url(const std::string & url);
 std::string escape_spaces(const std::string & url);
 
 class RESOURCE_RETRIEVER_PUBLIC RetrieverPlugin

--- a/resource_retriever/include/resource_retriever/resource.hpp
+++ b/resource_retriever/include/resource_retriever/resource.hpp
@@ -26,28 +26,40 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef RESOURCE_RETRIEVER__PLUGINS__FILESYSTEM_RETRIEVER_HPP_
-#define RESOURCE_RETRIEVER__PLUGINS__FILESYSTEM_RETRIEVER_HPP_
+#ifndef RESOURCE_RETRIEVER__RESOURCE_HPP_
+#define RESOURCE_RETRIEVER__RESOURCE_HPP_
 
+#include <cstdint>
+#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
-#include "resource_retriever/plugins/retriever_plugin.hpp"
 #include "resource_retriever/visibility_control.hpp"
 
-namespace resource_retriever::plugins
+namespace resource_retriever
 {
-
-class RESOURCE_RETRIEVER_PUBLIC FilesystemRetriever : public RetrieverPlugin
+/**
+ * \brief A retrieved resource, containing the url, expanded url, and binary data.
+ */
+struct RESOURCE_RETRIEVER_PUBLIC Resource
 {
-public:
-  FilesystemRetriever();
-  ~FilesystemRetriever() override;
-
-  bool can_handle(const std::string & url) override;
-  std::string name() override;
-  ResourceSharedPtr get_shared(const std::string & url) override;
+  explicit Resource(
+    std::string url_in,
+    std::string expanded_url_in,
+    std::vector<uint8_t> data_in)
+  : url(std::move(url_in)),
+    expanded_url(std::move(expanded_url_in)),
+    data(std::move(data_in))
+  {
+  }
+  const std::string url;
+  const std::string expanded_url;
+  const std::vector<uint8_t> data;
 };
 
-}  //  namespace resource_retriever::plugins
+using ResourceSharedPtr = std::shared_ptr<Resource>;
 
-#endif  // RESOURCE_RETRIEVER__PLUGINS__FILESYSTEM_RETRIEVER_HPP_
+}  //  namespace resource_retriever
+
+#endif  // RESOURCE_RETRIEVER__RESOURCE_HPP_

--- a/resource_retriever/include/resource_retriever/retriever.hpp
+++ b/resource_retriever/include/resource_retriever/retriever.hpp
@@ -33,30 +33,18 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
+#include "resource_retriever/plugins/retriever_plugin.hpp"
 #include "resource_retriever/visibility_control.hpp"
-
-using CURL = void;
 
 namespace resource_retriever
 {
-class Exception : public std::runtime_error
-{
-public:
-  Exception(const std::string & file, const std::string & error_msg)
-  : std::runtime_error("Error retrieving file [" + file + "]: " + error_msg)
-  {
-  }
-};
 
-/**
- * \brief A combination of a pointer to data in memory along with the data's size.
- */
-struct MemoryResource
-{
-  std::shared_ptr<uint8_t> data;
-  size_t size {0};
-};
+using RetrieverPluginPtr = std::shared_ptr<plugins::RetrieverPlugin>;
+using RetrieverVec = std::vector<RetrieverPluginPtr>;
+
+RetrieverVec RESOURCE_RETRIEVER_PUBLIC default_plugins();
 
 /**
  * \brief Retrieves files from from a url.  Caches a CURL handle so multiple accesses to a single url
@@ -65,15 +53,9 @@ struct MemoryResource
 class RESOURCE_RETRIEVER_PUBLIC Retriever
 {
 public:
-  Retriever();
+  explicit Retriever(RetrieverVec plugins = default_plugins());
 
   ~Retriever();
-
-  Retriever(const Retriever & ret) = delete;
-  Retriever & operator=(const Retriever & other) = delete;
-
-  Retriever(Retriever && other) noexcept;
-  Retriever & operator=(Retriever && other) noexcept;
 
   /**
    * \brief Get a file and store it in memory
@@ -81,10 +63,10 @@ public:
    * \return The file, loaded into memory
    * \throws resource_retriever::Exception if anything goes wrong.
    */
-  MemoryResource get(const std::string & url);
+  MemoryResourcePtr get(const std::string & url);
 
 private:
-  CURL * curl_handle_ {nullptr};
+  RetrieverVec plugins;
 };
 
 }  //  namespace resource_retriever

--- a/resource_retriever/include/resource_retriever/retriever.hpp
+++ b/resource_retriever/include/resource_retriever/retriever.hpp
@@ -34,7 +34,9 @@
 #include <string>
 #include <vector>
 
+#include "resource_retriever/memory_resource.hpp"
 #include "resource_retriever/plugins/retriever_plugin.hpp"
+#include "resource_retriever/resource.hpp"
 #include "resource_retriever/visibility_control.hpp"
 
 namespace resource_retriever
@@ -71,7 +73,7 @@ public:
    * \return The file, loaded into memory
    * \throws resource_retriever::Exception if anything goes wrong.
    */
-  MemoryResourceSharedPtr get_shared(const std::string & url);
+  ResourceSharedPtr get_shared(const std::string & url);
 
 private:
   RetrieverVec plugins;

--- a/resource_retriever/include/resource_retriever/retriever.hpp
+++ b/resource_retriever/include/resource_retriever/retriever.hpp
@@ -31,7 +31,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -41,8 +40,8 @@
 namespace resource_retriever
 {
 
-using RetrieverPluginPtr = std::shared_ptr<plugins::RetrieverPlugin>;
-using RetrieverVec = std::vector<RetrieverPluginPtr>;
+using RetrieverPluginSharedPtr = std::shared_ptr<plugins::RetrieverPlugin>;
+using RetrieverVec = std::vector<RetrieverPluginSharedPtr>;
 
 RetrieverVec RESOURCE_RETRIEVER_PUBLIC default_plugins();
 
@@ -63,7 +62,16 @@ public:
    * \return The file, loaded into memory
    * \throws resource_retriever::Exception if anything goes wrong.
    */
-  MemoryResourcePtr get(const std::string & url);
+  [[deprecated("Use get_shared(const std::string & url) instead.")]]
+  MemoryResource get(const std::string & url);
+
+  /**
+   * \brief Get a file and store it in memory
+   * \param url The url to retrieve.  package://package/file will be turned into the correct file:// invocation
+   * \return The file, loaded into memory
+   * \throws resource_retriever::Exception if anything goes wrong.
+   */
+  MemoryResourceSharedPtr get_shared(const std::string & url);
 
 private:
   RetrieverVec plugins;

--- a/resource_retriever/include/resource_retriever/retriever.hpp
+++ b/resource_retriever/include/resource_retriever/retriever.hpp
@@ -46,7 +46,7 @@ using RetrieverVec = std::vector<RetrieverPluginSharedPtr>;
 RetrieverVec RESOURCE_RETRIEVER_PUBLIC default_plugins();
 
 /**
- * \brief Retrieves files from from a url.  Caches a CURL handle so multiple accesses to a single url
+ * \brief Retrieves files from from a url. Caches a CURL handle so multiple accesses to a single url
  * will keep connections open.
  */
 class RESOURCE_RETRIEVER_PUBLIC Retriever
@@ -58,7 +58,7 @@ public:
 
   /**
    * \brief Get a file and store it in memory
-   * \param url The url to retrieve.  package://package/file will be turned into the correct file:// invocation
+   * \param url The url to retrieve. package://package/file will be turned into the correct file:// invocation
    * \return The file, loaded into memory
    * \throws resource_retriever::Exception if anything goes wrong.
    */
@@ -67,7 +67,7 @@ public:
 
   /**
    * \brief Get a file and store it in memory
-   * \param url The url to retrieve.  package://package/file will be turned into the correct file:// invocation
+   * \param url The url to retrieve. package://package/file will be turned into the correct file:// invocation
    * \return The file, loaded into memory
    * \throws resource_retriever::Exception if anything goes wrong.
    */

--- a/resource_retriever/include/resource_retriever/retriever.hpp
+++ b/resource_retriever/include/resource_retriever/retriever.hpp
@@ -34,6 +34,7 @@
 #include <string>
 #include <vector>
 
+#include "resource_retriever/exception.hpp"
 #include "resource_retriever/memory_resource.hpp"
 #include "resource_retriever/plugins/retriever_plugin.hpp"
 #include "resource_retriever/resource.hpp"

--- a/resource_retriever/src/plugins/curl_retriever.cpp
+++ b/resource_retriever/src/plugins/curl_retriever.cpp
@@ -1,0 +1,157 @@
+// Copyright 2009, Willow Garage, Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the  Willow Garage, Inc. nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "resource_retriever/plugins/curl_retriever.hpp"
+
+#include <curl/curl.h>
+
+#include <array>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "resource_retriever/exception.hpp"
+
+namespace
+{
+
+class CURLStaticInit
+{
+public:
+  CURLStaticInit()
+  {
+    CURLcode ret = curl_global_init(CURL_GLOBAL_ALL);
+    if (ret != 0) {
+      fprintf(stderr, "Error initializing libcurl! retcode = %d", ret);
+    } else {
+      initialized_ = true;
+    }
+  }
+
+  ~CURLStaticInit()
+  {
+    if (initialized_) {
+      curl_global_cleanup();
+    }
+  }
+
+private:
+  bool initialized_ {false};
+};
+CURLStaticInit g_curl_init;
+}  // namespace
+
+namespace resource_retriever::plugins
+{
+
+struct MemoryBuffer
+{
+  std::vector<uint8_t> v;
+};
+
+size_t curlWriteFunc(void * buffer, size_t size, size_t nmemb, void * userp)
+{
+  auto * membuf = reinterpret_cast<MemoryBuffer *>(userp);
+  size_t prev_size = membuf->v.size();
+  membuf->v.resize(prev_size + size * nmemb);
+  memcpy(&membuf->v[prev_size], buffer, size * nmemb);
+  return size * nmemb;
+}
+
+CurlRetriever::CurlRetriever():
+  curl_handle_(curl_easy_init())
+{
+
+}
+CurlRetriever::~CurlRetriever()
+{
+  if (curl_handle_ != nullptr) {
+    curl_easy_cleanup(curl_handle_);
+  }
+}
+
+CurlRetriever::CurlRetriever(CurlRetriever && other) noexcept
+: curl_handle_(std::exchange(other.curl_handle_, nullptr))
+{
+}
+
+CurlRetriever & CurlRetriever::operator=(CurlRetriever && other) noexcept
+{
+  std::swap(curl_handle_, other.curl_handle_);
+  return *this;
+}
+
+
+
+std::string CurlRetriever::name() {
+  return "resource_retriever::plugins::CurlRetriever";
+}
+
+bool CurlRetriever::can_handle(const std::string & url)
+{
+  return (url.find("package://") == 0 ||
+          url.find("file://") == 0 ||
+          url.find("http://") == 0 ||
+          url.find("https://") == 0);
+}
+
+MemoryResourcePtr CurlRetriever::get(const std::string & url)
+{
+  // Expand package:// url into file://
+  auto mod_url = url;
+  try {
+    mod_url = expand_package_url(mod_url);
+  } catch (const resource_retriever::Exception &e) {
+    return nullptr;
+  }
+
+  // newer versions of curl do not accept spaces in URLs
+  mod_url = escape_spaces(mod_url);
+
+  curl_easy_setopt(curl_handle_, CURLOPT_URL, mod_url.c_str());
+  curl_easy_setopt(curl_handle_, CURLOPT_WRITEFUNCTION, curlWriteFunc);
+
+  char error_buffer[CURL_ERROR_SIZE];
+  curl_easy_setopt(curl_handle_, CURLOPT_ERRORBUFFER, error_buffer);
+
+  MemoryResourcePtr res {nullptr};
+  MemoryBuffer buf;
+  curl_easy_setopt(curl_handle_, CURLOPT_WRITEDATA, &buf);
+
+  CURLcode ret = curl_easy_perform(curl_handle_);
+
+  if (ret == 0 && !buf.v.empty()) {
+    res = std::make_shared<MemoryResource>(buf.v);
+  }
+
+  return res;
+}
+
+}  // namespace resource_retriever::plugins

--- a/resource_retriever/src/plugins/curl_retriever.cpp
+++ b/resource_retriever/src/plugins/curl_retriever.cpp
@@ -108,8 +108,6 @@ CurlRetriever & CurlRetriever::operator=(CurlRetriever && other) noexcept
   return *this;
 }
 
-
-
 std::string CurlRetriever::name() {
   return "resource_retriever::plugins::CurlRetriever";
 }

--- a/resource_retriever/src/plugins/curl_retriever.cpp
+++ b/resource_retriever/src/plugins/curl_retriever.cpp
@@ -148,7 +148,7 @@ MemoryResourcePtr CurlRetriever::get(const std::string & url)
   CURLcode ret = curl_easy_perform(curl_handle_);
 
   if (ret == 0 && !buf.v.empty()) {
-    res = std::make_shared<MemoryResource>(buf.v);
+    res = std::make_shared<MemoryResource>(url, mod_url, buf.v);
   }
 
   return res;

--- a/resource_retriever/src/plugins/curl_retriever.cpp
+++ b/resource_retriever/src/plugins/curl_retriever.cpp
@@ -136,7 +136,7 @@ bool CurlRetriever::can_handle(const std::string & url)
     url.find("https://") == 0;
 }
 
-MemoryResourcePtr CurlRetriever::get(const std::string & url)
+MemoryResourceSharedPtr CurlRetriever::get_shared(const std::string & url)
 {
   // Expand package:// url into file://
   auto mod_url = url;
@@ -155,7 +155,7 @@ MemoryResourcePtr CurlRetriever::get(const std::string & url)
   char error_buffer[CURL_ERROR_SIZE];
   curl_easy_setopt(curl_handle_, CURLOPT_ERRORBUFFER, error_buffer);
 
-  MemoryResourcePtr res {nullptr};
+  MemoryResourceSharedPtr res {nullptr};
   MemoryBuffer buf;
   curl_easy_setopt(curl_handle_, CURLOPT_WRITEDATA, &buf);
 

--- a/resource_retriever/src/plugins/curl_retriever.cpp
+++ b/resource_retriever/src/plugins/curl_retriever.cpp
@@ -30,10 +30,9 @@
 
 #include <curl/curl.h>
 
-#include <array>
 #include <cstring>
-#include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -42,16 +41,13 @@
 
 namespace
 {
-
 class CURLStaticInit
 {
 public:
   CURLStaticInit()
   {
-    CURLcode ret = curl_global_init(CURL_GLOBAL_ALL);
-    if (ret != 0) {
-      std::cerr << "Error initializing libcurl! retcode = " << ret;
-    } else {
+    ret_ = curl_global_init(CURL_GLOBAL_ALL);
+    if (ret_ == CURLE_OK) {
       initialized_ = true;
     }
   }
@@ -63,8 +59,19 @@ public:
     }
   }
 
+  /// Check that libcurl is globally initialized, otherwise throw.
+  void check_if_initialized() const
+  {
+    if (!this->initialized_) {
+      throw std::runtime_error(
+        "curl_global_init(CURL_GLOBAL_ALL) failed (" + std::to_string(ret_) + "): " +
+        curl_easy_strerror(ret_));
+    }
+  }
+
 private:
   bool initialized_ {false};
+  CURLcode ret_ = CURLE_OK;
 };
 CURLStaticInit g_curl_init;
 }  // namespace
@@ -86,8 +93,14 @@ size_t curlWriteFunc(void * buffer, size_t size, size_t nmemb, void * userp)
   return size * nmemb;
 }
 
+CURL * do_curl_easy_init()
+{
+  ::g_curl_init.check_if_initialized();
+  return curl_easy_init();
+}
+
 CurlRetriever::CurlRetriever()
-:curl_handle_(curl_easy_init())
+: curl_handle_(do_curl_easy_init())
 {
 }
 
@@ -116,10 +129,11 @@ std::string CurlRetriever::name()
 
 bool CurlRetriever::can_handle(const std::string & url)
 {
-  return  url.find("package://") == 0 ||
-         url.find("file://") == 0 ||
-         url.find("http://") == 0 ||
-         url.find("https://") == 0;
+  return
+    url.find("package://") == 0 ||
+    url.find("file://") == 0 ||
+    url.find("http://") == 0 ||
+    url.find("https://") == 0;
 }
 
 MemoryResourcePtr CurlRetriever::get(const std::string & url)

--- a/resource_retriever/src/plugins/curl_retriever.cpp
+++ b/resource_retriever/src/plugins/curl_retriever.cpp
@@ -30,6 +30,7 @@
 
 #include <curl/curl.h>
 
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <stdexcept>

--- a/resource_retriever/src/plugins/curl_retriever.cpp
+++ b/resource_retriever/src/plugins/curl_retriever.cpp
@@ -141,11 +141,7 @@ ResourceSharedPtr CurlRetriever::get_shared(const std::string & url)
 {
   // Expand package:// url into file://
   auto mod_url = url;
-  try {
-    mod_url = expand_package_url(mod_url);
-  } catch (const resource_retriever::Exception & e) {
-    return nullptr;
-  }
+  mod_url = expand_package_url(mod_url);
 
   // newer versions of curl do not accept spaces in URLs
   mod_url = escape_spaces(mod_url);
@@ -161,6 +157,9 @@ ResourceSharedPtr CurlRetriever::get_shared(const std::string & url)
   curl_easy_setopt(curl_handle_, CURLOPT_WRITEDATA, &buf);
 
   CURLcode ret = curl_easy_perform(curl_handle_);
+  if (ret != 0) {
+    throw Exception(mod_url, error_buffer);
+  }
 
   if (ret == 0 && !buf.v.empty()) {
     res = std::make_shared<Resource>(url, mod_url, buf.v);

--- a/resource_retriever/src/plugins/curl_retriever.cpp
+++ b/resource_retriever/src/plugins/curl_retriever.cpp
@@ -32,6 +32,7 @@
 
 #include <array>
 #include <cstring>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <utility>
@@ -49,7 +50,7 @@ public:
   {
     CURLcode ret = curl_global_init(CURL_GLOBAL_ALL);
     if (ret != 0) {
-      fprintf(stderr, "Error initializing libcurl! retcode = %d", ret);
+      std::cerr << "Error initializing libcurl! retcode = " << ret;
     } else {
       initialized_ = true;
     }
@@ -85,11 +86,11 @@ size_t curlWriteFunc(void * buffer, size_t size, size_t nmemb, void * userp)
   return size * nmemb;
 }
 
-CurlRetriever::CurlRetriever():
-  curl_handle_(curl_easy_init())
+CurlRetriever::CurlRetriever()
+:curl_handle_(curl_easy_init())
 {
-
 }
+
 CurlRetriever::~CurlRetriever()
 {
   if (curl_handle_ != nullptr) {
@@ -108,16 +109,17 @@ CurlRetriever & CurlRetriever::operator=(CurlRetriever && other) noexcept
   return *this;
 }
 
-std::string CurlRetriever::name() {
+std::string CurlRetriever::name()
+{
   return "resource_retriever::plugins::CurlRetriever";
 }
 
 bool CurlRetriever::can_handle(const std::string & url)
 {
-  return (url.find("package://") == 0 ||
-          url.find("file://") == 0 ||
-          url.find("http://") == 0 ||
-          url.find("https://") == 0);
+  return  url.find("package://") == 0 ||
+         url.find("file://") == 0 ||
+         url.find("http://") == 0 ||
+         url.find("https://") == 0;
 }
 
 MemoryResourcePtr CurlRetriever::get(const std::string & url)
@@ -126,7 +128,7 @@ MemoryResourcePtr CurlRetriever::get(const std::string & url)
   auto mod_url = url;
   try {
     mod_url = expand_package_url(mod_url);
-  } catch (const resource_retriever::Exception &e) {
+  } catch (const resource_retriever::Exception & e) {
     return nullptr;
   }
 

--- a/resource_retriever/src/plugins/curl_retriever.cpp
+++ b/resource_retriever/src/plugins/curl_retriever.cpp
@@ -137,7 +137,7 @@ bool CurlRetriever::can_handle(const std::string & url)
     url.find("https://") == 0;
 }
 
-MemoryResourceSharedPtr CurlRetriever::get_shared(const std::string & url)
+ResourceSharedPtr CurlRetriever::get_shared(const std::string & url)
 {
   // Expand package:// url into file://
   auto mod_url = url;
@@ -156,14 +156,14 @@ MemoryResourceSharedPtr CurlRetriever::get_shared(const std::string & url)
   char error_buffer[CURL_ERROR_SIZE];
   curl_easy_setopt(curl_handle_, CURLOPT_ERRORBUFFER, error_buffer);
 
-  MemoryResourceSharedPtr res {nullptr};
+  ResourceSharedPtr res {nullptr};
   MemoryBuffer buf;
   curl_easy_setopt(curl_handle_, CURLOPT_WRITEDATA, &buf);
 
   CURLcode ret = curl_easy_perform(curl_handle_);
 
   if (ret == 0 && !buf.v.empty()) {
-    res = std::make_shared<MemoryResource>(url, mod_url, buf.v);
+    res = std::make_shared<Resource>(url, mod_url, buf.v);
   }
 
   return res;

--- a/resource_retriever/src/plugins/filesystem_retriever.cpp
+++ b/resource_retriever/src/plugins/filesystem_retriever.cpp
@@ -82,7 +82,7 @@ MemoryResourcePtr FilesystemRetriever::get(const std::string & url)
     std::vector<uint8_t> data(fileSize);
     file.read(reinterpret_cast<char*>(data.data()), fileSize);
     file.close();
-    res = std::make_shared<MemoryResource>(data);
+    res = std::make_shared<MemoryResource>(url, mod_url, data);
   }
 
   return res;

--- a/resource_retriever/src/plugins/filesystem_retriever.cpp
+++ b/resource_retriever/src/plugins/filesystem_retriever.cpp
@@ -52,7 +52,7 @@ bool FilesystemRetriever::can_handle(const std::string & url)
   return url.find("package://") == 0 || url.find("file://") == 0;
 }
 
-MemoryResourcePtr FilesystemRetriever::get(const std::string & url)
+MemoryResourceSharedPtr FilesystemRetriever::get_shared(const std::string & url)
 {
   // Expand package:// url into file://
   auto mod_url = url;
@@ -67,7 +67,7 @@ MemoryResourcePtr FilesystemRetriever::get(const std::string & url)
   }
 
   std::ifstream file(mod_url, std::ios::binary);
-  MemoryResourcePtr res {nullptr};
+  MemoryResourceSharedPtr res {nullptr};
 
   if (file.is_open()) {
     // Get the file size

--- a/resource_retriever/src/plugins/filesystem_retriever.cpp
+++ b/resource_retriever/src/plugins/filesystem_retriever.cpp
@@ -45,7 +45,8 @@ FilesystemRetriever::FilesystemRetriever() = default;
 
 FilesystemRetriever::~FilesystemRetriever() = default;
 
-std::string FilesystemRetriever::name() {
+std::string FilesystemRetriever::name()
+{
   return "resource_retriever::plugins::FilesystemRetriever";
 }
 
@@ -60,12 +61,11 @@ MemoryResourcePtr FilesystemRetriever::get(const std::string & url)
   auto mod_url = url;
   try {
     mod_url = expand_package_url(mod_url);
-  } catch (const resource_retriever::Exception &e) {
+  } catch (const resource_retriever::Exception & e) {
     return nullptr;
   }
 
-  if (mod_url.find("file://") == 0)
-  {
+  if (mod_url.find("file://") == 0) {
     mod_url = mod_url.substr(7);
   }
 
@@ -80,7 +80,7 @@ MemoryResourcePtr FilesystemRetriever::get(const std::string & url)
 
     // Create the vector and read the file
     std::vector<uint8_t> data(fileSize);
-    file.read(reinterpret_cast<char*>(data.data()), fileSize);
+    file.read(reinterpret_cast<char *>(data.data()), fileSize);
     file.close();
     res = std::make_shared<MemoryResource>(url, mod_url, data);
   }

--- a/resource_retriever/src/plugins/filesystem_retriever.cpp
+++ b/resource_retriever/src/plugins/filesystem_retriever.cpp
@@ -29,6 +29,7 @@
 #include "resource_retriever/plugins/filesystem_retriever.hpp"
 
 #include <fstream>
+#include <ios>
 #include <memory>
 #include <string>
 #include <vector>

--- a/resource_retriever/src/plugins/filesystem_retriever.cpp
+++ b/resource_retriever/src/plugins/filesystem_retriever.cpp
@@ -72,13 +72,7 @@ MemoryResourceSharedPtr FilesystemRetriever::get_shared(const std::string & url)
 
   if (file.is_open()) {
     // Get the file size
-    file.seekg(0, std::ios::end);
-    std::streampos fileSize = file.tellg();
-    file.seekg(0, std::ios::beg);
-
-    // Create the vector and read the file
-    std::vector<uint8_t> data(fileSize);
-    file.read(reinterpret_cast<char *>(data.data()), fileSize);
+    std::vector<uint8_t> data(std::istreambuf_iterator<char>(file), {});
     file.close();
     res = std::make_shared<MemoryResource>(url, mod_url, data);
   }

--- a/resource_retriever/src/plugins/filesystem_retriever.cpp
+++ b/resource_retriever/src/plugins/filesystem_retriever.cpp
@@ -28,12 +28,9 @@
 
 #include "resource_retriever/plugins/filesystem_retriever.hpp"
 
-#include <array>
-#include <cstring>
 #include <fstream>
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "resource_retriever/exception.hpp"

--- a/resource_retriever/src/plugins/filesystem_retriever.cpp
+++ b/resource_retriever/src/plugins/filesystem_retriever.cpp
@@ -57,11 +57,7 @@ ResourceSharedPtr FilesystemRetriever::get_shared(const std::string & url)
 {
   // Expand package:// url into file://
   auto mod_url = url;
-  try {
-    mod_url = expand_package_url(mod_url);
-  } catch (const resource_retriever::Exception & e) {
-    return nullptr;
-  }
+  mod_url = expand_package_url(mod_url);
 
   if (mod_url.find("file://") == 0) {
     mod_url = mod_url.substr(7);
@@ -75,6 +71,8 @@ ResourceSharedPtr FilesystemRetriever::get_shared(const std::string & url)
     std::vector<uint8_t> data(std::istreambuf_iterator<char>(file), {});
     file.close();
     res = std::make_shared<Resource>(url, mod_url, data);
+  } else {
+    throw Exception(mod_url, "Failed to open file");
   }
 
   return res;

--- a/resource_retriever/src/plugins/filesystem_retriever.cpp
+++ b/resource_retriever/src/plugins/filesystem_retriever.cpp
@@ -53,7 +53,7 @@ bool FilesystemRetriever::can_handle(const std::string & url)
   return url.find("package://") == 0 || url.find("file://") == 0;
 }
 
-MemoryResourceSharedPtr FilesystemRetriever::get_shared(const std::string & url)
+ResourceSharedPtr FilesystemRetriever::get_shared(const std::string & url)
 {
   // Expand package:// url into file://
   auto mod_url = url;
@@ -68,13 +68,13 @@ MemoryResourceSharedPtr FilesystemRetriever::get_shared(const std::string & url)
   }
 
   std::ifstream file(mod_url, std::ios::binary);
-  MemoryResourceSharedPtr res {nullptr};
+  ResourceSharedPtr res {nullptr};
 
   if (file.is_open()) {
     // Get the file size
     std::vector<uint8_t> data(std::istreambuf_iterator<char>(file), {});
     file.close();
-    res = std::make_shared<MemoryResource>(url, mod_url, data);
+    res = std::make_shared<Resource>(url, mod_url, data);
   }
 
   return res;

--- a/resource_retriever/src/plugins/retriever_plugin.cpp
+++ b/resource_retriever/src/plugins/retriever_plugin.cpp
@@ -1,0 +1,91 @@
+// Copyright 2009, Willow Garage, Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the  Willow Garage, Inc. nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "resource_retriever/plugins/retriever_plugin.hpp"
+
+#include <cstring>
+
+#include "resource_retriever/exception.hpp"
+
+#include "ament_index_cpp/get_package_prefix.hpp"
+#include "ament_index_cpp/get_package_share_directory.hpp"
+
+namespace resource_retriever::plugins
+{
+
+std::string escape_spaces(const std::string & url)
+{
+  std::string new_mod_url;
+  new_mod_url.reserve(url.length());
+
+  std::string::size_type last_pos = 0;
+  std::string::size_type find_pos;
+
+  while (std::string::npos != (find_pos = url.find(' ', last_pos))) {
+    new_mod_url.append(url, last_pos, find_pos - last_pos);
+    new_mod_url += "%20";
+    last_pos = find_pos + std::string(" ").length();
+  }
+
+  // Take care for the rest after last occurrence
+  new_mod_url.append(url, last_pos, url.length() - last_pos);
+  return new_mod_url;
+}
+
+std::string expand_package_url(const std::string & url)
+{
+  std::string mod_url = url;
+  if (url.find("package://") == 0) {
+    mod_url.erase(0, strlen("package://"));
+    size_t pos = mod_url.find('/');
+    if (pos == std::string::npos) {
+      throw Exception(url, "Could not parse package:// format into file:// format");
+    }
+
+    std::string package = mod_url.substr(0, pos);
+    if (package.empty()) {
+      throw Exception(url, "Package name must not be empty");
+    }
+    mod_url.erase(0, pos);
+    std::string package_path;
+    try {
+      package_path = ament_index_cpp::get_package_share_directory(package);
+    } catch (const ament_index_cpp::PackageNotFoundError &) {
+      throw Exception(url, "Package [" + package + "] does not exist");
+    }
+
+    mod_url = "file://" + package_path + mod_url;
+  }
+  return mod_url;
+};
+
+RetrieverPlugin::RetrieverPlugin() = default;
+
+RetrieverPlugin::~RetrieverPlugin() = default;
+
+}  // namespace resource_retriever::plugins

--- a/resource_retriever/src/plugins/retriever_plugin.cpp
+++ b/resource_retriever/src/plugins/retriever_plugin.cpp
@@ -82,7 +82,7 @@ std::string expand_package_url(const std::string & url)
     mod_url = "file://" + package_path + mod_url;
   }
   return mod_url;
-};
+}
 
 RetrieverPlugin::RetrieverPlugin() = default;
 

--- a/resource_retriever/src/plugins/retriever_plugin.cpp
+++ b/resource_retriever/src/plugins/retriever_plugin.cpp
@@ -28,7 +28,8 @@
 
 #include "resource_retriever/plugins/retriever_plugin.hpp"
 
-#include <cstring>
+#include <string>
+#include <string_view>
 
 #include "resource_retriever/exception.hpp"
 
@@ -59,12 +60,15 @@ std::string escape_spaces(const std::string & url)
 
 std::string expand_package_url(const std::string & url)
 {
+  constexpr std::string_view package_url_prefix = "package://";
   std::string mod_url = url;
-  if (url.find("package://") == 0) {
-    mod_url.erase(0, strlen("package://"));
+  if (url.find(package_url_prefix) == 0) {
+    mod_url.erase(0, package_url_prefix.length());
     size_t pos = mod_url.find('/');
     if (pos == std::string::npos) {
-      throw Exception(url, "Could not parse package:// format into file:// format");
+      throw Exception(
+        url,
+        "Could not parse " + std::string(package_url_prefix) + " format into file:// format");
     }
 
     std::string package = mod_url.substr(0, pos);

--- a/resource_retriever/src/retriever.cpp
+++ b/resource_retriever/src/retriever.cpp
@@ -50,8 +50,8 @@ RetrieverVec default_plugins()
   };
 }
 
-Retriever::Retriever(RetrieverVec plugins):
-  plugins(std::move(plugins))
+Retriever::Retriever(RetrieverVec plugins)
+:plugins(std::move(plugins))
 {
 }
 
@@ -59,14 +59,13 @@ Retriever::~Retriever() = default;
 
 MemoryResourcePtr Retriever::get(const std::string & url)
 {
-  for (auto & plugin : plugins)
-  {
-    if (plugin->can_handle(url))
-    {
+  for (auto & plugin : plugins) {
+    if (plugin->can_handle(url)) {
       auto res = plugin->get(url);
 
-      if (res != nullptr)
+      if (res != nullptr) {
         return res;
+      }
     }
   }
   return nullptr;

--- a/resource_retriever/src/retriever.cpp
+++ b/resource_retriever/src/retriever.cpp
@@ -28,6 +28,7 @@
 
 #include "resource_retriever/retriever.hpp"
 
+#include <cstring>
 #include <memory>
 #include <string>
 #include <utility>
@@ -55,12 +56,32 @@ Retriever::Retriever(RetrieverVec plugins)
 
 Retriever::~Retriever() = default;
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 MemoryResource Retriever::get(const std::string & url)
 {
-  return *get_shared(url);
+  auto resource_shared_ptr = get_shared(url);
+  MemoryResource memory_resource;
+  memory_resource.size = resource_shared_ptr->data.size();
+  // Converted from boost::shared_array, see: https://stackoverflow.com/a/8624884
+  memory_resource.data.reset(new uint8_t[memory_resource.size], std::default_delete<uint8_t[]>());
+  memcpy(memory_resource.data.get(), &resource_shared_ptr->data[0], memory_resource.size);
+  return memory_resource;
 }
 
-MemoryResourceSharedPtr Retriever::get_shared(const std::string & url)
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
+#endif
+
+ResourceSharedPtr Retriever::get_shared(const std::string & url)
 {
   for (auto & plugin : plugins) {
     if (plugin->can_handle(url)) {

--- a/resource_retriever/src/retriever.cpp
+++ b/resource_retriever/src/retriever.cpp
@@ -68,6 +68,10 @@ MemoryResource Retriever::get(const std::string & url)
 {
   auto resource_shared_ptr = get_shared(url);
   MemoryResource memory_resource;
+  if (!resource_shared_ptr) {
+    // resource not found, return empty MemoryResource
+    return memory_resource;
+  }
   memory_resource.size = resource_shared_ptr->data.size();
   // Converted from boost::shared_array, see: https://stackoverflow.com/a/8624884
   memory_resource.data.reset(new uint8_t[memory_resource.size], std::default_delete<uint8_t[]>());

--- a/resource_retriever/src/retriever.cpp
+++ b/resource_retriever/src/retriever.cpp
@@ -55,11 +55,16 @@ Retriever::Retriever(RetrieverVec plugins)
 
 Retriever::~Retriever() = default;
 
-MemoryResourcePtr Retriever::get(const std::string & url)
+MemoryResource Retriever::get(const std::string & url)
+{
+  return *get_shared(url);
+}
+
+MemoryResourceSharedPtr Retriever::get_shared(const std::string & url)
 {
   for (auto & plugin : plugins) {
     if (plugin->can_handle(url)) {
-      auto res = plugin->get(url);
+      auto res = plugin->get_shared(url);
 
       if (res != nullptr) {
         return res;

--- a/resource_retriever/src/retriever.cpp
+++ b/resource_retriever/src/retriever.cpp
@@ -28,11 +28,9 @@
 
 #include "resource_retriever/retriever.hpp"
 
-#include <cstring>
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "resource_retriever/exception.hpp"
 #include "resource_retriever/plugins/curl_retriever.hpp"

--- a/resource_retriever/test/test.cpp
+++ b/resource_retriever/test/test.cpp
@@ -94,8 +94,7 @@ public:
   }
 
   resource_retriever::MemoryResourcePtr get(const std::string & url) override {
-    (void) url;
-    return std::make_shared<resource_retriever::MemoryResource>(std::vector<uint8_t>{0, 1, 2, 3, 4, 5});
+    return std::make_shared<resource_retriever::MemoryResource>(url, url, std::vector<uint8_t>{0, 1, 2, 3, 4, 5});
   }
 };
 

--- a/resource_retriever/test/test.cpp
+++ b/resource_retriever/test/test.cpp
@@ -75,10 +75,11 @@ TEST(Retriever, invalidFiles)
 {
   resource_retriever::Retriever r;
 
-  EXPECT_EQ(nullptr, r.get_shared("file://fail"));
-  EXPECT_EQ(nullptr, r.get_shared("package://roscpp"));
-  EXPECT_EQ(nullptr, r.get_shared("package://invalid_package_blah/test.xml"));
-  EXPECT_EQ(nullptr, r.get_shared("package:///test.xml"));
+  EXPECT_THROW(r.get_shared("file://fail"), resource_retriever::Exception);
+  EXPECT_THROW(r.get_shared("package://roscpp"), resource_retriever::Exception);
+  EXPECT_THROW(r.get_shared("package://invalid_package_blah/test.xml"),
+    resource_retriever::Exception);
+  EXPECT_THROW(r.get_shared("package:///test.xml"), resource_retriever::Exception);
 }
 
 class TestRetrieverPlugin : public resource_retriever::plugins::RetrieverPlugin

--- a/resource_retriever/test/test.cpp
+++ b/resource_retriever/test/test.cpp
@@ -97,9 +97,9 @@ public:
     return url.find("test://") == 0;
   }
 
-  resource_retriever::MemoryResourceSharedPtr get_shared(const std::string & url) override
+  resource_retriever::ResourceSharedPtr get_shared(const std::string & url) override
   {
-    return std::make_shared<resource_retriever::MemoryResource>(
+    return std::make_shared<resource_retriever::Resource>(
         url, url, std::vector<uint8_t>{0, 1, 2, 3, 4, 5});
   }
 };

--- a/resource_retriever/test/test.cpp
+++ b/resource_retriever/test/test.cpp
@@ -26,8 +26,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <string>
 #include <exception>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "gtest/gtest.h"
 

--- a/resource_retriever/test/test.cpp
+++ b/resource_retriever/test/test.cpp
@@ -48,7 +48,7 @@ TEST(Retriever, getByPackage)
 {
   try {
     resource_retriever::Retriever r;
-    auto res = r.get("package://resource_retriever/test/test.txt");
+    auto res = r.get_shared("package://resource_retriever/test/test.txt");
 
     ASSERT_NE(nullptr, res);
     ASSERT_EQ(res->data.size(), 1u);
@@ -62,7 +62,7 @@ TEST(Retriever, http)
 {
   try {
     resource_retriever::Retriever r;
-    auto res = r.get("http://packages.ros.org/ros.key");
+    auto res = r.get_shared("http://packages.ros.org/ros.key");
 
     ASSERT_NE(nullptr, res);
     ASSERT_GT(res->data.size(), 0u);
@@ -75,10 +75,10 @@ TEST(Retriever, invalidFiles)
 {
   resource_retriever::Retriever r;
 
-  EXPECT_EQ(nullptr, r.get("file://fail"));
-  EXPECT_EQ(nullptr, r.get("package://roscpp"));
-  EXPECT_EQ(nullptr, r.get("package://invalid_package_blah/test.xml"));
-  EXPECT_EQ(nullptr, r.get("package:///test.xml"));
+  EXPECT_EQ(nullptr, r.get_shared("file://fail"));
+  EXPECT_EQ(nullptr, r.get_shared("package://roscpp"));
+  EXPECT_EQ(nullptr, r.get_shared("package://invalid_package_blah/test.xml"));
+  EXPECT_EQ(nullptr, r.get_shared("package:///test.xml"));
 }
 
 class TestRetrieverPlugin : public resource_retriever::plugins::RetrieverPlugin
@@ -97,7 +97,7 @@ public:
     return url.find("test://") == 0;
   }
 
-  resource_retriever::MemoryResourcePtr get(const std::string & url) override
+  resource_retriever::MemoryResourceSharedPtr get_shared(const std::string & url) override
   {
     return std::make_shared<resource_retriever::MemoryResource>(
         url, url, std::vector<uint8_t>{0, 1, 2, 3, 4, 5});
@@ -111,11 +111,11 @@ TEST(Retriever, customPlugin)
   };
 
   resource_retriever::Retriever r(plugins);
-  EXPECT_EQ(nullptr, r.get("package://resource_retriever/test/text.txt"));
-  EXPECT_EQ(nullptr, r.get("file://foo/bar/text.txt"));
-  EXPECT_NE(nullptr, r.get("test://foo"));
+  EXPECT_EQ(nullptr, r.get_shared("package://resource_retriever/test/text.txt"));
+  EXPECT_EQ(nullptr, r.get_shared("file://foo/bar/text.txt"));
+  EXPECT_NE(nullptr, r.get_shared("test://foo"));
 
-  auto res = r.get("test://foo");
+  auto res = r.get_shared("test://foo");
   EXPECT_EQ(res->data.size(), 6u);
   EXPECT_EQ(res->data[0], 0u);
   EXPECT_EQ(res->data[1], 1u);

--- a/resource_retriever/test/test.cpp
+++ b/resource_retriever/test/test.cpp
@@ -79,22 +79,26 @@ TEST(Retriever, invalidFiles)
   EXPECT_EQ(nullptr, r.get("package:///test.xml"));
 }
 
-class TestRetrieverPlugin: public resource_retriever::plugins::RetrieverPlugin
+class TestRetrieverPlugin : public resource_retriever::plugins::RetrieverPlugin
 {
 public:
-    TestRetrieverPlugin() = default;
-    ~TestRetrieverPlugin() override = default;
+  TestRetrieverPlugin() = default;
+  ~TestRetrieverPlugin() override = default;
 
-    std::string name() override {
-      return "TestRetrieverPlugin";
-    }
+  std::string name() override
+  {
+    return "TestRetrieverPlugin";
+  }
 
-  bool can_handle(const std::string & url) override {
+  bool can_handle(const std::string & url) override
+  {
     return url.find("test://") == 0;
   }
 
-  resource_retriever::MemoryResourcePtr get(const std::string & url) override {
-    return std::make_shared<resource_retriever::MemoryResource>(url, url, std::vector<uint8_t>{0, 1, 2, 3, 4, 5});
+  resource_retriever::MemoryResourcePtr get(const std::string & url) override
+  {
+    return std::make_shared<resource_retriever::MemoryResource>(
+        url, url, std::vector<uint8_t>{0, 1, 2, 3, 4, 5});
   }
 };
 


### PR DESCRIPTION
The idea behind this is to make `resource_retriever` pluggable.  That is that downstream users of the library can choose the mechanisms that they want to back the calls to "get".

This will allow for things like retrieving over ROS services or parameters.