### PR TITLE
Updated to cpp20

### DIFF
--- a/resource_retriever/CMakeLists.txt
+++ b/resource_retriever/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(CURL REQUIRED)
 # TODO(wjwwood): split cpp and python apis into separate packages
 add_library(${PROJECT_NAME}
   src/retriever.cpp
+  src/exception.cpp
   src/plugins/retriever_plugin.cpp
   src/plugins/filesystem_retriever.cpp
   src/plugins/curl_retriever.cpp

--- a/resource_retriever/CMakeLists.txt
+++ b/resource_retriever/CMakeLists.txt
@@ -1,17 +1,15 @@
 cmake_minimum_required(VERSION 3.14)
 project(resource_retriever)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
+# The C++/C standard comes from ament_ros_defaults (cxx_std_20 / c_std_17),
+# linked PRIVATE below so it applies to this library's own translation units
+# only and is not propagated to downstream consumers.
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(CURL REQUIRED)
 
@@ -31,6 +29,11 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   ament_index_cpp::ament_index_cpp
   CURL::libcurl
 )
+# ament_ros_defaults is an INTERFACE target providing cxx_std_20 / c_std_17.
+# Linked PRIVATE so the standard applies to our own sources without leaking
+# into the exported interface (a SHARED library does not propagate PRIVATE
+# link requirements to consumers).
+target_link_libraries(${PROJECT_NAME} PRIVATE ament_cmake_ros_core::ament_ros_defaults)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -52,7 +55,10 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gtest(${PROJECT_NAME}_test test/test.cpp)
-  target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME})
+  target_link_libraries(${PROJECT_NAME}_test
+    ${PROJECT_NAME}
+    ament_cmake_ros_core::ament_ros_defaults
+  )
 
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(resource_retriever_python_test test/test.py

--- a/resource_retriever/include/resource_retriever/exception.hpp
+++ b/resource_retriever/include/resource_retriever/exception.hpp
@@ -30,8 +30,10 @@
 #ifndef RESOURCE_RETRIEVER__EXCEPTION_HPP_
 #define RESOURCE_RETRIEVER__EXCEPTION_HPP_
 
+#include <format>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 #include "resource_retriever/visibility_control.hpp"
 
@@ -41,8 +43,8 @@ class Exception : public std::runtime_error
 {
 public:
   RESOURCE_RETRIEVER_PUBLIC
-  Exception(const std::string & file, const std::string & error_msg)
-  : std::runtime_error("Error retrieving file [" + file + "]: " + error_msg)
+  Exception(std::string_view file, std::string_view error_msg)
+  : std::runtime_error(std::format("Error retrieving file [{}]: {}", file, error_msg))
   {
   }
 };

--- a/resource_retriever/include/resource_retriever/plugins/retriever_plugin.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/retriever_plugin.hpp
@@ -37,7 +37,17 @@
 namespace resource_retriever::plugins
 {
 std::string expand_package_url(const std::string & url);
-std::string escape_spaces(const std::string & url);
+
+/// Percent-encode a single URL component (e.g. one path segment).
+std::string url_encode(const std::string & decoded);
+
+/// Percent-decode a single URL component.
+std::string url_decode(const std::string & encoded);
+
+/// Percent-encode the path of a URL while leaving the scheme, authority and
+/// '/' separators untouched, so that libcurl accepts paths containing spaces
+/// or other special characters.
+std::string encode_uri(const std::string & url);
 
 class RESOURCE_RETRIEVER_PUBLIC RetrieverPlugin
 {

--- a/resource_retriever/include/resource_retriever/plugins/retriever_plugin.hpp
+++ b/resource_retriever/include/resource_retriever/plugins/retriever_plugin.hpp
@@ -36,17 +36,21 @@
 
 namespace resource_retriever::plugins
 {
+RESOURCE_RETRIEVER_PUBLIC
 std::string expand_package_url(const std::string & url);
 
 /// Percent-encode a single URL component (e.g. one path segment).
+RESOURCE_RETRIEVER_PUBLIC
 std::string url_encode(const std::string & decoded);
 
 /// Percent-decode a single URL component.
+RESOURCE_RETRIEVER_PUBLIC
 std::string url_decode(const std::string & encoded);
 
 /// Percent-encode the path of a URL while leaving the scheme, authority and
 /// '/' separators untouched, so that libcurl accepts paths containing spaces
 /// or other special characters.
+RESOURCE_RETRIEVER_PUBLIC
 std::string encode_uri(const std::string & url);
 
 class RESOURCE_RETRIEVER_PUBLIC RetrieverPlugin

--- a/resource_retriever/package.xml
+++ b/resource_retriever/package.xml
@@ -24,6 +24,7 @@
   <url type="bugtracker">https://github.com/ros/robot_model/issues</url>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
   <depend>ament_index_python</depend>

--- a/resource_retriever/src/exception.cpp
+++ b/resource_retriever/src/exception.cpp
@@ -27,22 +27,17 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef RESOURCE_RETRIEVER__EXCEPTION_HPP_
-#define RESOURCE_RETRIEVER__EXCEPTION_HPP_
+#include "resource_retriever/exception.hpp"
 
-#include <stdexcept>
+#include <format>
 #include <string_view>
-
-#include "resource_retriever/visibility_control.hpp"
 
 namespace resource_retriever
 {
-class Exception : public std::runtime_error
-{
-public:
-  RESOURCE_RETRIEVER_PUBLIC
-  Exception(std::string_view file, std::string_view error_msg);
-};
-}  // namespace resource_retriever
 
-#endif  // RESOURCE_RETRIEVER__EXCEPTION_HPP_
+Exception::Exception(std::string_view file, std::string_view error_msg)
+: std::runtime_error(std::format("Error retrieving file [{}]: {}", file, error_msg))
+{
+}
+
+}  // namespace resource_retriever

--- a/resource_retriever/src/plugins/curl_retriever.cpp
+++ b/resource_retriever/src/plugins/curl_retriever.cpp
@@ -32,7 +32,9 @@
 
 #include <cstdint>
 #include <cstring>
+#include <format>  // NOLINT(build/include_order) cpplint <C++20 misclassifies as C header
 #include <memory>
+#include <span>  // NOLINT(build/include_order) cpplint <C++20 misclassifies as C header
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -65,8 +67,9 @@ public:
   {
     if (!this->initialized_) {
       throw std::runtime_error(
-        "curl_global_init(CURL_GLOBAL_ALL) failed (" + std::to_string(ret_) + "): " +
-        curl_easy_strerror(ret_));
+        std::format(
+          "curl_global_init(CURL_GLOBAL_ALL) failed ({}): {}",
+          static_cast<int>(ret_), curl_easy_strerror(ret_)));
     }
   }
 
@@ -88,10 +91,9 @@ struct MemoryBuffer
 size_t curlWriteFunc(void * buffer, size_t size, size_t nmemb, void * userp)
 {
   auto * membuf = reinterpret_cast<MemoryBuffer *>(userp);
-  size_t prev_size = membuf->v.size();
-  membuf->v.resize(prev_size + size * nmemb);
-  memcpy(&membuf->v[prev_size], buffer, size * nmemb);
-  return size * nmemb;
+  const std::span<const uint8_t> chunk{static_cast<const uint8_t *>(buffer), size * nmemb};
+  membuf->v.insert(membuf->v.end(), chunk.begin(), chunk.end());
+  return chunk.size();
 }
 
 CURL * do_curl_easy_init()
@@ -131,20 +133,17 @@ std::string CurlRetriever::name()
 bool CurlRetriever::can_handle(const std::string & url)
 {
   return
-    url.find("package://") == 0 ||
-    url.find("file://") == 0 ||
-    url.find("http://") == 0 ||
-    url.find("https://") == 0;
+    url.starts_with("package://") ||
+    url.starts_with("file://") ||
+    url.starts_with("http://") ||
+    url.starts_with("https://");
 }
 
 ResourceSharedPtr CurlRetriever::get_shared(const std::string & url)
 {
-  // Expand package:// url into file://
-  auto mod_url = url;
-  mod_url = expand_package_url(mod_url);
-
-  // newer versions of curl do not accept spaces in URLs
-  mod_url = escape_spaces(mod_url);
+  // Expand package:// url into file://, then escape spaces because newer
+  // versions of curl do not accept spaces in URLs.
+  std::string mod_url = escape_spaces(expand_package_url(url));
 
   curl_easy_setopt(curl_handle_, CURLOPT_URL, mod_url.c_str());
   curl_easy_setopt(curl_handle_, CURLOPT_WRITEFUNCTION, curlWriteFunc);
@@ -152,20 +151,19 @@ ResourceSharedPtr CurlRetriever::get_shared(const std::string & url)
   char error_buffer[CURL_ERROR_SIZE];
   curl_easy_setopt(curl_handle_, CURLOPT_ERRORBUFFER, error_buffer);
 
-  ResourceSharedPtr res {nullptr};
   MemoryBuffer buf;
   curl_easy_setopt(curl_handle_, CURLOPT_WRITEDATA, &buf);
 
   CURLcode ret = curl_easy_perform(curl_handle_);
-  if (ret != 0) {
+  if (ret != CURLE_OK) {
     throw Exception(mod_url, error_buffer);
   }
 
-  if (ret == 0 && !buf.v.empty()) {
-    res = std::make_shared<Resource>(url, mod_url, buf.v);
+  if (buf.v.empty()) {
+    return nullptr;
   }
 
-  return res;
+  return std::make_shared<Resource>(url, std::move(mod_url), std::move(buf.v));
 }
 
 }  // namespace resource_retriever::plugins

--- a/resource_retriever/src/plugins/curl_retriever.cpp
+++ b/resource_retriever/src/plugins/curl_retriever.cpp
@@ -141,9 +141,10 @@ bool CurlRetriever::can_handle(const std::string & url)
 
 ResourceSharedPtr CurlRetriever::get_shared(const std::string & url)
 {
-  // Expand package:// url into file://, then escape spaces because newer
-  // versions of curl do not accept spaces in URLs.
-  std::string mod_url = escape_spaces(expand_package_url(url));
+  // Expand package:// url into file://, then percent-encode the path because
+  // newer versions of curl do not accept spaces (or other special characters)
+  // in URLs.
+  std::string mod_url = encode_uri(expand_package_url(url));
 
   curl_easy_setopt(curl_handle_, CURLOPT_URL, mod_url.c_str());
   curl_easy_setopt(curl_handle_, CURLOPT_WRITEFUNCTION, curlWriteFunc);

--- a/resource_retriever/src/plugins/filesystem_retriever.cpp
+++ b/resource_retriever/src/plugins/filesystem_retriever.cpp
@@ -32,6 +32,8 @@
 #include <ios>
 #include <memory>
 #include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 #include "resource_retriever/exception.hpp"
@@ -50,32 +52,26 @@ std::string FilesystemRetriever::name()
 
 bool FilesystemRetriever::can_handle(const std::string & url)
 {
-  return url.find("package://") == 0 || url.find("file://") == 0;
+  return url.starts_with("package://") || url.starts_with("file://");
 }
 
 ResourceSharedPtr FilesystemRetriever::get_shared(const std::string & url)
 {
   // Expand package:// url into file://
-  auto mod_url = url;
-  mod_url = expand_package_url(mod_url);
+  std::string mod_url = expand_package_url(url);
 
-  if (mod_url.find("file://") == 0) {
-    mod_url = mod_url.substr(7);
+  constexpr std::string_view file_scheme = "file://";
+  if (mod_url.starts_with(file_scheme)) {
+    mod_url.erase(0, file_scheme.length());
   }
 
   std::ifstream file(mod_url, std::ios::binary);
-  ResourceSharedPtr res {nullptr};
-
-  if (file.is_open()) {
-    // Get the file size
-    std::vector<uint8_t> data(std::istreambuf_iterator<char>(file), {});
-    file.close();
-    res = std::make_shared<Resource>(url, mod_url, data);
-  } else {
+  if (!file.is_open()) {
     throw Exception(mod_url, "Failed to open file");
   }
 
-  return res;
+  std::vector<uint8_t> data(std::istreambuf_iterator<char>(file), {});
+  return std::make_shared<Resource>(url, std::move(mod_url), std::move(data));
 }
 
 }  // namespace resource_retriever::plugins

--- a/resource_retriever/src/plugins/retriever_plugin.cpp
+++ b/resource_retriever/src/plugins/retriever_plugin.cpp
@@ -29,6 +29,7 @@
 #include "resource_retriever/plugins/retriever_plugin.hpp"
 
 #include <filesystem>
+#include <format>  // NOLINT(build/include_order) cpplint <C++20 misclassifies as C header
 #include <string>
 #include <string_view>
 
@@ -45,17 +46,13 @@ std::string escape_spaces(const std::string & url)
   std::string new_mod_url;
   new_mod_url.reserve(url.length());
 
-  std::string::size_type last_pos = 0;
-  std::string::size_type find_pos;
-
-  while (std::string::npos != (find_pos = url.find(' ', last_pos))) {
-    new_mod_url.append(url, last_pos, find_pos - last_pos);
-    new_mod_url += "%20";
-    last_pos = find_pos + std::string(" ").length();
+  for (const char c : url) {
+    if (c == ' ') {
+      new_mod_url += "%20";
+    } else {
+      new_mod_url += c;
+    }
   }
-
-  // Take care for the rest after last occurrence
-  new_mod_url.append(url, last_pos, url.length() - last_pos);
   return new_mod_url;
 }
 
@@ -63,13 +60,13 @@ std::string expand_package_url(const std::string & url)
 {
   constexpr std::string_view package_url_prefix = "package://";
   std::string mod_url = url;
-  if (url.find(package_url_prefix) == 0) {
+  if (url.starts_with(package_url_prefix)) {
     mod_url.erase(0, package_url_prefix.length());
     size_t pos = mod_url.find('/');
     if (pos == std::string::npos) {
       throw Exception(
         url,
-        "Could not parse " + std::string(package_url_prefix) + " format into file:// format");
+        std::format("Could not parse {} format into file:// format", package_url_prefix));
     }
 
     std::string package = mod_url.substr(0, pos);
@@ -81,7 +78,7 @@ std::string expand_package_url(const std::string & url)
     try {
       package_path = ament_index_cpp::get_package_share_path(package);
     } catch (const ament_index_cpp::PackageNotFoundError &) {
-      throw Exception(url, "Package [" + package + "] does not exist");
+      throw Exception(url, std::format("Package [{}] does not exist", package));
     }
 
     mod_url = "file://" + package_path.string() + mod_url;

--- a/resource_retriever/src/plugins/retriever_plugin.cpp
+++ b/resource_retriever/src/plugins/retriever_plugin.cpp
@@ -28,6 +28,9 @@
 
 #include "resource_retriever/plugins/retriever_plugin.hpp"
 
+#include <curl/curl.h>
+
+#include <cstddef>
 #include <filesystem>
 #include <format>  // NOLINT(build/include_order) cpplint <C++20 misclassifies as C header
 #include <string>
@@ -41,19 +44,61 @@
 namespace resource_retriever::plugins
 {
 
-std::string escape_spaces(const std::string & url)
+std::string url_encode(const std::string & decoded)
 {
-  std::string new_mod_url;
-  new_mod_url.reserve(url.length());
-
-  for (const char c : url) {
-    if (c == ' ') {
-      new_mod_url += "%20";
-    } else {
-      new_mod_url += c;
-    }
+  char * encoded = curl_easy_escape(nullptr, decoded.c_str(), static_cast<int>(decoded.length()));
+  if (encoded == nullptr) {
+    return decoded;
   }
-  return new_mod_url;
+  std::string result(encoded);
+  curl_free(encoded);
+  return result;
+}
+
+std::string url_decode(const std::string & encoded)
+{
+  int output_length = 0;
+  char * decoded = curl_easy_unescape(
+    nullptr, encoded.c_str(), static_cast<int>(encoded.length()), &output_length);
+  if (decoded == nullptr) {
+    return encoded;
+  }
+  std::string result(decoded, static_cast<size_t>(output_length));
+  curl_free(decoded);
+  return result;
+}
+
+std::string encode_uri(const std::string & url)
+{
+  // curl_easy_escape() percent-encodes every reserved character, including the
+  // "scheme://" delimiters and the '/' path separators, so it cannot be applied
+  // to a whole URL. Instead keep the scheme and authority verbatim and encode
+  // each path segment individually, preserving the '/' separators.
+  constexpr std::string_view scheme_separator = "://";
+  const size_t scheme_pos = url.find(scheme_separator);
+  if (scheme_pos == std::string::npos) {
+    return url;
+  }
+
+  const size_t authority_pos = scheme_pos + scheme_separator.length();
+  const size_t path_pos = url.find('/', authority_pos);
+  if (path_pos == std::string::npos) {
+    return url;
+  }
+
+  // Keep "scheme://authority" untouched, then percent-encode each '/'-delimited
+  // path segment.
+  std::string result = url.substr(0, path_pos);
+  for (size_t segment_start = path_pos; segment_start < url.length(); ) {
+    size_t segment_end = url.find('/', segment_start + 1);
+    if (segment_end == std::string::npos) {
+      segment_end = url.length();
+    }
+    result += '/';
+    result += url_encode(url.substr(segment_start + 1, segment_end - segment_start - 1));
+    segment_start = segment_end;
+  }
+  return result;
 }
 
 std::string expand_package_url(const std::string & url)

--- a/resource_retriever/test/test.cpp
+++ b/resource_retriever/test/test.cpp
@@ -121,6 +121,43 @@ TEST(Retriever, customPlugin)
   EXPECT_EQ(res->data[1], 1u);
 }
 
+TEST(Retriever, urlEncodeDecodeRoundTrip)
+{
+  using resource_retriever::plugins::url_decode;
+  using resource_retriever::plugins::url_encode;
+
+  EXPECT_EQ(url_encode("a b"), "a%20b");
+  EXPECT_EQ(url_decode("a%20b"), "a b");
+
+  const std::string raw = "weird (v2)#1?x.dae";
+  EXPECT_EQ(url_decode(url_encode(raw)), raw);
+}
+
+TEST(Retriever, encodeUri)
+{
+  using resource_retriever::plugins::encode_uri;
+
+  // The path is percent-encoded while the scheme, authority and '/' separators
+  // are left untouched.
+  EXPECT_EQ(
+    encode_uri("file:///home/me/my model.dae"),
+    "file:///home/me/my%20model.dae");
+  EXPECT_EQ(
+    encode_uri("file:///home/me/part (v2)/m#1.dae"),
+    "file:///home/me/part%20%28v2%29/m%231.dae");
+  EXPECT_EQ(
+    encode_uri("https://example.com/a b/c.stl"),
+    "https://example.com/a%20b/c.stl");
+
+  // URLs without special characters are returned unchanged.
+  EXPECT_EQ(
+    encode_uri("http://packages.ros.org/ros.key"),
+    "http://packages.ros.org/ros.key");
+
+  // URLs without a path component are returned unchanged.
+  EXPECT_EQ(encode_uri("file://fail"), "file://fail");
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
 - use std::move, std::format and std::span
 - simplified escape_spaces
- ament_cmake_ros_core::ament_ros_defaults (linked PRIVATE) instead of a hardcoded CMAKE_CXX_STANDARD. 

@asymingt FYI

Claude Opus 4.7